### PR TITLE
Link edm4hep to FWCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,14 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5)
 
 
 find_package(ROOT COMPONENTS RIO Tree)
+find_package(podio)
+find_package(EDM4HEP)
 
 #---------------------------------------------------------------
 # Load macros and functions for Gaudi-based projects
 find_package(GaudiProject)
 #---------------------------------------------------------------
+
 
 include(GNUInstallDirs)
 

--- a/FWCore/CMakeLists.txt
+++ b/FWCore/CMakeLists.txt
@@ -12,7 +12,7 @@ gaudi_install_python_modules()
 gaudi_add_library(FWCore
 		  src/*.cpp
                   INCLUDE_DIRS podio ROOT
-                  LINK_LIBRARIES GaudiAlgLib GaudiKernel ROOT podio::podioRootIO EDM4HEP::edm4hep
+                  LINK_LIBRARIES GaudiAlgLib GaudiKernel ROOT podio::podioRootIO EDM4HEP::edm4hepDict
                   PUBLIC_HEADERS FWCore)
 
 gaudi_add_module(FWCorePlugins

--- a/FWCore/CMakeLists.txt
+++ b/FWCore/CMakeLists.txt
@@ -3,7 +3,6 @@
 ################################################################################
 gaudi_subdir(FWCore v1r0)
 
-find_package(podio)
 
 # this declaration will not be needed in the future
 gaudi_depends_on_subdirs(GaudiAlg GaudiKernel)
@@ -13,7 +12,7 @@ gaudi_install_python_modules()
 gaudi_add_library(FWCore
 		  src/*.cpp
                   INCLUDE_DIRS podio ROOT
-                  LINK_LIBRARIES GaudiAlgLib GaudiKernel podio::podioRootIO ROOT
+                  LINK_LIBRARIES GaudiAlgLib GaudiKernel ROOT podio::podioRootIO EDM4HEP::edm4hep
                   PUBLIC_HEADERS FWCore)
 
 gaudi_add_module(FWCorePlugins


### PR DESCRIPTION
... so subdirectories linking to FWCore do not have to specify it explicitly.