### PR TITLE
Update Deprecated Gaudi Header Include

### DIFF
--- a/FWCore/FWCore/DataHandle.h
+++ b/FWCore/FWCore/DataHandle.h
@@ -4,12 +4,8 @@
 #include "FWCore/DataWrapper.h"
 #include "FWCore/PodioDataSvc.h"
 
-#include "GaudiKernel/AlgTool.h"
-#include "GaudiKernel/Algorithm.h"
-#include <GaudiKernel/DataObjectHandle.h>
-#include <GaudiKernel/GaudiException.h>
-#include <GaudiKernel/Property.h>
-#include <GaudiKernel/ServiceLocatorHelper.h>
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/DataObjectHandle.h"
 
 #include "TTree.h"
 


### PR DESCRIPTION
To remove warnings and allow update to v35r0, see https://gitlab.cern.ch/gaudi/Gaudi/-/blob/master/GaudiKernel/GaudiKernel/Property.h