### PR TITLE
[cmake] use Gaudi namespace to link targets

### DIFF
--- a/k4FWCore/CMakeLists.txt
+++ b/k4FWCore/CMakeLists.txt
@@ -10,7 +10,7 @@ gaudi_install(SCRIPTS)
 gaudi_add_library(k4FWCore
 		  SOURCES src/PodioDataSvc.cpp
               src/KeepDropSwitch.cpp
-                  LINK GaudiAlgLib GaudiKernel podio::podioRootIO ROOT::Core ROOT::RIO ROOT::Tree
+                  LINK Gaudi::GaudiAlgLib Gaudi::GaudiKernel podio::podioRootIO ROOT::Core ROOT::RIO ROOT::Tree
                   )
 target_include_directories(k4FWCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
@@ -22,7 +22,7 @@ target_include_directories(k4FWCore PUBLIC
 file(GLOB k4fwcore_plugin_sources components/*.cpp)
 gaudi_add_module(k4FWCorePlugins
                  SOURCES ${k4fwcore_plugin_sources}
-                 LINK GaudiAlgLib GaudiKernel k4FWCore ROOT::Core ROOT::RIO ROOT::Tree)
+                 LINK Gaudi::GaudiAlgLib Gaudi::GaudiKernel k4FWCore ROOT::Core ROOT::RIO ROOT::Tree)
 target_include_directories(k4FWCorePlugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/test/k4TestFWCore/CMakeLists.txt
+++ b/test/k4TestFWCore/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(EDM4HEP)
 file(GLOB k4testfwcore_plugin_sources src/components/*.cpp)
 gaudi_add_module(k4TestFWCorePlugins
                  SOURCES ${k4testfwcore_plugin_sources}
-                 LINK GaudiAlgLib GaudiKernel k4FWCore ROOT::Core ROOT::RIO ROOT::Tree EDM4HEP::edm4hepDict EDM4HEP::edm4hep)
+                 LINK Gaudi::GaudiAlgLib Gaudi::GaudiKernel k4FWCore ROOT::Core ROOT::RIO ROOT::Tree EDM4HEP::edm4hepDict EDM4HEP::edm4hep)
 
 
 include(CTest)


### PR DESCRIPTION
As mentioned in https://github.com/key4hep/k4FWCore/issues/31, otherwise there is
a linker error using dependencies based on the LCG releases.

Fixes #31 