### PR TITLE
K4 print joboptions fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,50 +8,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SETUP: ["init.sh"]
+        SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sft.cern.ch/lcg/views/LCG_99/x86_64-centos7-gcc8-opt/setup.sh']
     steps:
     - uses: actions/checkout@v2
-    - uses: cvmfs-contrib/github-action-cvmfs@v1
-      with:
-        cvmfs_repositories: 'sw.hsf.org,sw-nightlies.hsf.org,sft-nightlies.cern.ch,sft.cern.ch,geant4.cern.ch'
-
+    - uses: cvmfs-contrib/github-action-cvmfs@v2
     - name: Start container
       run: |
-        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d centos:centos7 /bin/bash
+        docker run -it --name CI_container -v ${GITHUB_WORKSPACE}:/Package -v /cvmfs:/cvmfs:shared -d clicdp/cc7-lcg /bin/bash
     - name: Setup container
       run: |
-        docker exec CI_container /bin/bash -c 'cd ./Package;\
-        yum install -q -y file git make automake glibc-devel unzip patch python3 bzip2 rsync which diffutils crontabs;\
-        curl -L -o spack.tar.gz https://gitlab.cern.ch/key4hep/k4-deploy/-/jobs/artifacts/master/raw/key4hep-spack_centos7-cvmfs.tar.gz?job=setup_spack_push; \
-        tar xfz spack.tar.gz;'
-
-    - name: Compile
+        docker exec CI_container /bin/bash -c " ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;"
+    - name: CMake Configure
+      run: |
+        docker exec CI_container /bin/bash -c 'cd Package;\
+         mkdir -p build install;\
+         source ${{ matrix.SETUP }};\
+         cd build;\
+         cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
+    - name: Compile 
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
-        source spack/share/spack/setup-env.sh;\
-        spack dev-build  k4fwcore@master;\
-        '
-
+        source ${{ matrix.SETUP }};\
+        cd build;\
+        ninja -k0;'
+    - name: Install
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+          source ${{ matrix.SETUP }};\
+          cd build;\
+          ninja -k0 install;'
     - name: Test
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
-        source spack/share/spack/setup-env.sh;\
-        spack load k4fwcore@master;\
-        spack load edm4hep;\
-        spack load cmake;\
-        rm spack-build-*.txt;\
-        cd spack-build-*;\
-        ctest --output-on-failure;'
-
-    - name: Downstream Package CMake Test
-      run: |
-        docker exec CI_container /bin/bash -c 'cd ./Package;\
-        source /cvmfs/sw.hsf.org/contrib/linux-centos7-broadwell/gcc-8.3.0/setup.sh;\
-        source spack/share/spack/setup-env.sh;\
-        spack load k4fwcore@master;\
-        spack load cmake;\
-        cd test/downstream-project-cmake-test;\
-        mkdir build install;\
+        source ${{ matrix.SETUP }};\
         cd build;\
-        cmake ..;\
-        make'
+        ninja -k0 && ctest --output-on-failure;'
+

--- a/k4FWCore/scripts/k4-print-joboptions
+++ b/k4FWCore/scripts/k4-print-joboptions
@@ -49,7 +49,7 @@ def _sanitize(s):
 
 
 def dump_joboptions(filename):
-  f = ROOT.TFile(filename)
+  f = ROOT.TFile.Open(filename)
   t = f.metadata
   for event in t:
       s =  event.gaudiConfigOptions

--- a/k4FWCore/scripts/k4-print-joboptions
+++ b/k4FWCore/scripts/k4-print-joboptions
@@ -32,6 +32,8 @@ def _sanitize(s):
   s: str
     The sanitized string that should be compatible with gaudirun.py
   """
+  # convert s to standard string (might be a root string)
+  s = str(s)
   s = s.replace('"False"', 'False')
   s = s.replace('"True"', 'True')
   s = s.replace('"[', '[')

--- a/test/k4TestFWCore/CMakeLists.txt
+++ b/test/k4TestFWCore/CMakeLists.txt
@@ -15,28 +15,49 @@ gaudi_add_module(k4TestFWCorePlugins
 
 include(CTest)
 
-#set(K4RUN ${CMAKE_BINARY_DIR}/run ${PROJECT_SOURCE_DIR}/k4FWCore/scripts/k4run)
 set(K4RUN ${PROJECT_SOURCE_DIR}/k4FWCore/scripts/k4run)
+
+get_target_property(edm4hep_lib EDM4HEP::edm4hepDict LOCATION)
+get_filename_component(edm4hep_loc ${edm4hep_lib} DIRECTORY)
+
+get_target_property(root_lib ROOT::Core LOCATION)
+get_filename_component(root_loc ${root_lib} DIRECTORY)
+
+get_target_property(podio_lib podio::podio LOCATION)
+get_filename_component(podio_loc ${podio_lib} DIRECTORY)
+
+function(set_test_env _testname)
+  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "ROOT_INCLUDE_PATH=${podio_loc}/../include/podio:${edm4hep_loc}/../include:$ENV{ROOT_INCLUDE_PATH}")
+  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}:${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}:${CMAKE_BINARY_DIR}/test/k4TestFWCore:${root_loc}:${edm4hep_loc}:${podio_loc}:$ENV{LD_LIBRARY_PATH}")
+  set_property(TEST ${_testname} APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/${CMAKE_PROJECT_NAME}/genConf:${CMAKE_BINARY_DIR}/test/k4TestFWCore/genConf:$ENV{PYTHONPATH}")
+endfunction()
 
 
 add_test(NAME CreateExampleEventData
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/createExampleEventData.py)
+set_test_env(CreateExampleEventData)
 
 add_test(NAME ReadExampleEventData
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/readExampleEventData.py)
+set_test_env(ReadExampleEventData)
+set_property(TEST ReadExampleEventData APPEND PROPERTY DEPENDS CreateExampleEventData)
 
 add_test(NAME AlgorithmWithTFile
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/TestAlgorithmWithTFile.py)
+set_test_env(AlgorithmWithTFile)
 
 add_test(NAME AlgorithmWithTFileCheckFrameworkOutput
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND  python scripts/check_TestAlgorithmWithTFile_framework_nonempty.py)
 set_property(TEST AlgorithmWithTFileCheckFrameworkOutput APPEND PROPERTY DEPENDS AlgorithmWithTFile)
+set_test_env(AlgorithmWithTFileCheckFrameworkOutput)
 
 add_test(NAME AlgorithmWithTFileCheckMyTFileOutput
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND  python scripts/check_TestAlgorithmWithTFile_myTFile_nonempty.py)
 set_property(TEST AlgorithmWithTFileCheckMyTFileOutput APPEND PROPERTY DEPENDS AlgorithmWithTFile)
+set_test_env(AlgorithmWithTFileCheckMyTFileOutput)
+


### PR DESCRIPTION

[k4-print-joboptions] fix for root string types
[k4-print-joboptions] use TFile::Open instead of ctor to allow opening remote files (https/xrootd)

