### PR TITLE
Add an option to ignore the first N events in the input stream

### DIFF
--- a/k4FWCore/components/k4DataSvc.cpp
+++ b/k4FWCore/components/k4DataSvc.cpp
@@ -9,6 +9,7 @@ DECLARE_COMPONENT(k4DataSvc)
 k4DataSvc::k4DataSvc(const std::string& name, ISvcLocator* svc) : PodioDataSvc(name, svc) {
   declareProperty("inputs", m_filenames = {}, "Names of the files to read");
   declareProperty("input", m_filename = "", "Name of the file to read");
+  declareProperty("FirstEventEntry", m_1stEvtEntry = 0, "First event to read");
 }
 
 /// Standard Destructor

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -79,5 +79,8 @@ protected:
   /// ROOT file name the input is read from. Set by option filename
   std::vector<std::string> m_filenames;
   std::string m_filename;
+  /// Jump to nth events at the beginning. Set by option FirstEventEntry
+  /// This option is helpful when we want to debug an event in the middle of a file
+  unsigned m_1stEvtEntry{0};
 };
 #endif  // CORE_PODIODATASVC_H

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -30,6 +30,11 @@ StatusCode PodioDataSvc::initialize() {
 
       setCollectionIDs(idTable);
       m_provider.setReader(&m_reader);
+
+      if (m_1stEvtEntry != 0 ) {
+          m_reader.goToEvent(m_1stEvtEntry);
+          m_eventMax -= m_1stEvtEntry;
+      }
     }
   }
   return status;

--- a/test/k4TestFWCore/CMakeLists.txt
+++ b/test/k4TestFWCore/CMakeLists.txt
@@ -27,6 +27,10 @@ add_test(NAME ReadExampleEventData
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/readExampleEventData.py)
 
+add_test(NAME ReadExampleDataFromNthEvent
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+         COMMAND ${K4RUN} options/readExampleDataFromNthEvent.py)
+
 add_test(NAME AlgorithmWithTFile
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/TestAlgorithmWithTFile.py)

--- a/test/k4TestFWCore/options/readExampleDataFromNthEvent.py
+++ b/test/k4TestFWCore/options/readExampleDataFromNthEvent.py
@@ -1,0 +1,24 @@
+from Gaudi.Configuration import *
+
+from Configurables import k4DataSvc
+podioevent = k4DataSvc("EventDataSvc")
+podioevent.input = "output_k4test_exampledata.root"
+podioevent.FirstEventEntry = 66
+
+from Configurables import PodioInput
+inp = PodioInput()
+inp.collections = ["MCParticles", "SimTrackerHits", "Tracks"]
+
+from Configurables import PodioOutput
+oup = PodioOutput()
+oup.filename = "output_k4test_exampledata_3.root"
+
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg=[inp, oup],
+                EvtSel="NONE",
+                EvtMax=5,
+                ExtSvc=[podioevent],
+                OutputLevel=DEBUG,
+                )
+
+


### PR DESCRIPTION
Sometimes we want to debug an appointed event. And we need to read events from the middle of a file, rather than from the beginning. With this update, users can set the first event to read from the input stream.