### PR TITLE
k4Run: change command line option for props to include the name

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -103,11 +103,12 @@ if __name__ == "__main__":
                           proptype = type(propvalue[0])
                         propnargs = "+"
                         
-                      parser.add_argument("--" + prop, type=proptype, help=props[prop][1],
+                      propName = conf.name() + '.' + prop
+                      parser.add_argument("--%s" % propName, type=proptype, help=props[prop][1],
                         nargs=propnargs,
                         default=propvalue)
                       # bookkeeping which option belongs to which configurable
-                      option_db[prop] = conf
+                      option_db[propName] = (conf, prop)
                     except argparse.ArgumentError:
                       pass
 
@@ -132,8 +133,8 @@ if __name__ == "__main__":
 
     # turn namespace into dict
     opts_dict = vars(opts)
-    for option in option_db:
-      option_db[option].setProp(option, opts_dict[option])
+    for optionName, propTuple in option_db.items():
+      propTuple[0].setProp(propTuple[1], opts_dict[optionName])
 
     if opts.verbose:
       ApplicationMgr().OutputLevel = VERBOSE


### PR DESCRIPTION
of the configurable and not just the name of the property

if there is more than one instance of a configurable (e.g., k4MarlinWrapper), one cannot otherwise set the option for them or if different configurables have the same property names.

BEGINRELEASENOTES
- k4run: change properties to include the name of the configurable: E.g. --Files --> --LcioEvent.Files

ENDRELEASENOTES
