### PR TITLE
[k4run] restore argument shortcuts where possible

### DIFF
--- a/k4FWCore/components/PodioOutput.h
+++ b/k4FWCore/components/PodioOutput.h
@@ -38,7 +38,7 @@ private:
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};
   Gaudi::Property<std::string> m_filenameRemote{
-      this, "filenameRemote", "", "An optional file path to copy the outputfile to."};
+      this, "remoteFilename", "", "An optional file path to copy the outputfile to."};
   /// Switch for keeping or dropping outputs
   KeepDropSwitch m_switch;
   /// Needed for collection ID table

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -82,43 +82,34 @@ if __name__ == "__main__":
                   if not hasattr(props[prop][0], '__slots__'):
                     # argparse ArgumentError: used to catch when trying to add
                     # same argument twice
-                    try:                       
-                      propvalue = props[prop][0]
+                    propvalue = props[prop][0]
 
-                      # if it is set to "no value" it hasn't been touched in the options file
+                    # if it is set to "no value" it hasn't been touched in the options file
 
-                      if propvalue == conf.propertyNoValue:
-                         propvalue = conf.getDefaultProperty(prop) # thus get the default value
-                      proptype = type(props[prop][0])
-                      # if the property is a list of something, we need to set argparse nargs to '+'
-                      propnargs = "?"
-                      if proptype == list:
-                        # tricky edgecase: if the default is an empty list there is no way to get the type
-                        if len(propvalue) == 0:
-                          # just skip for now
-                          #print("Warning: argparse cannot deduce type for property %s of %s. Needs to be set in options file." % (prop, conf.name()))
-                          continue
-                        else:
-                          # deduce type from first item of the list
-                          proptype = type(propvalue[0])
-                        propnargs = "+"
-                        
-                      propName = conf.name() + '.' + prop
-                      # try to add argument once as a shortcut (prop, p.ex '--filename')
-                      # and once with the full property name (propName, p.ex '--PodioOutput.filename')
-                      # if the argument is already present, an ArgumentError is raised that is dealt with below
-                      parser.add_argument("--%s" % prop, "--%s" % propName, type=proptype, help=props[prop][1],
-                        nargs=propnargs,
-                        default=propvalue)
-                      # bookkeeping which option belongs to which configurable
-                      option_db[propName] = (conf, prop)
-                    except argparse.ArgumentError:
-                      # argument already present, add it without shortcut
-                      parser.add_argument( "--%s" % propName, type=proptype, help=props[prop][1],
-                        nargs=propnargs,
-                        default=propvalue)
-                      option_db[propName] = (conf, prop)
-                      pass
+                    if propvalue == conf.propertyNoValue:
+                       propvalue = conf.getDefaultProperty(prop) # thus get the default value
+                    proptype = type(props[prop][0])
+                    # if the property is a list of something, we need to set argparse nargs to '+'
+                    propnargs = "?"
+                    if proptype == list:
+                      # tricky edgecase: if the default is an empty list there is no way to get the type
+                      if len(propvalue) == 0:
+                        # just skip for now
+                        #print("Warning: argparse cannot deduce type for property %s of %s. Needs to be set in options file." % (prop, conf.name()))
+                        continue
+                      else:
+                        # deduce type from first item of the list
+                        proptype = type(propvalue[0])
+                      propnargs = "+"
+                      
+                    propName = prop + '.' + conf.name()
+                    # try to add argument once as a shortcut (prop, p.ex '--filename')
+                    # and once with the full property name (propName, p.ex '--PodioOutput.filename')
+                    # if the argument is already present, an ArgumentError is raised that is dealt with below
+                    option_db[propName] = (conf, propName)
+                    parser.add_argument( "--%s" % propName, type=proptype, help=props[prop][1],
+                      nargs=propnargs,
+                      default=propvalue)
 
 
     opts=parser.parse_args()
@@ -138,12 +129,6 @@ if __name__ == "__main__":
     if not run_with_options_file:
       print("usage: " + os.path.basename(__file__) + " [gaudi_config.py ...] Specify a gaudi options file to run")
       sys.exit()
-
-    # turn namespace into dict
-    # (python 2 compatibility)
-    opts_dict = vars(opts)
-    for optionName, propTuple in option_db.items():
-      propTuple[0].setProp(propTuple[1], opts_dict[optionName])
 
     if opts.verbose:
       ApplicationMgr().OutputLevel = VERBOSE

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -80,8 +80,9 @@ if __name__ == "__main__":
               if not "Audit" in prop:
                 # do not want to deal with other components / datahandles for now
                   if not hasattr(props[prop][0], '__slots__'):
-                    #print(conf.name(), prop, props[prop])
-                    try: # TODO: remove once duplicate elements sorted out
+                    # argparse ArgumentError: used to catch when trying to add
+                    # same argument twice
+                    try:                       
                       propvalue = props[prop][0]
 
                       # if it is set to "no value" it hasn't been touched in the options file
@@ -91,7 +92,6 @@ if __name__ == "__main__":
                       proptype = type(props[prop][0])
                       # if the property is a list of something, we need to set argparse nargs to '+'
                       propnargs = "?"
-                      #print("proptype", proptype)
                       if proptype == list:
                         # tricky edgecase: if the default is an empty list there is no way to get the type
                         if len(propvalue) == 0:
@@ -104,12 +104,20 @@ if __name__ == "__main__":
                         propnargs = "+"
                         
                       propName = conf.name() + '.' + prop
-                      parser.add_argument("--%s" % propName, type=proptype, help=props[prop][1],
+                      # try to add argument once as a shortcut (prop, p.ex '--filename')
+                      # and once with the full property name (propName, p.ex '--PodioOutput.filename')
+                      # if the argument is already present, an ArgumentError is raised that is dealt with below
+                      parser.add_argument("--%s" % prop, "--%s" % propName, type=proptype, help=props[prop][1],
                         nargs=propnargs,
                         default=propvalue)
                       # bookkeeping which option belongs to which configurable
                       option_db[propName] = (conf, prop)
                     except argparse.ArgumentError:
+                      # argument already present, add it without shortcut
+                      parser.add_argument( "--%s" % propName, type=proptype, help=props[prop][1],
+                        nargs=propnargs,
+                        default=propvalue)
+                      option_db[propName] = (conf, prop)
                       pass
 
 
@@ -132,6 +140,7 @@ if __name__ == "__main__":
       sys.exit()
 
     # turn namespace into dict
+    # (python 2 compatibility)
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
       propTuple[0].setProp(propTuple[1], opts_dict[optionName])

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -80,8 +80,6 @@ if __name__ == "__main__":
               if not "Audit" in prop:
                 # do not want to deal with other components / datahandles for now
                   if not hasattr(props[prop][0], '__slots__'):
-                    # argparse ArgumentError: used to catch when trying to add
-                    # same argument twice
                     propvalue = props[prop][0]
 
                     # if it is set to "no value" it hasn't been touched in the options file

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -102,15 +102,14 @@ if __name__ == "__main__":
                         proptype = type(propvalue[0])
                       propnargs = "+"
                       
-                    propName = prop + '.' + conf.name()
-                    # try to add argument once as a shortcut (prop, p.ex '--filename')
-                    # and once with the full property name (propName, p.ex '--PodioOutput.filename')
-                    # if the argument is already present, an ArgumentError is raised that is dealt with below
+                    # add the argument twice, once as "--PodioOutput.filename"
+                    # and once as "--filename.PodioOutput"
+                    propName = conf.name() + '.' + prop
+                    propNameReversed = prop + '.' + conf.name()
                     option_db[propName] = (conf, propName)
-                    parser.add_argument( "--%s" % propName, type=proptype, help=props[prop][1],
+                    parser.add_argument( "--%s" % propName, "--%s" % propNameReversed, type=proptype, help=props[prop][1],
                       nargs=propnargs,
                       default=propvalue)
-
 
     opts=parser.parse_args()
 
@@ -137,11 +136,6 @@ if __name__ == "__main__":
     # Allow graceful exit with Ctrl + C
     ApplicationMgr().StopOnSignal = True
 
-
-
-
-
-
     # Parallel Option ---------------------------------------------------------
     if opts.ncpus:
         from multiprocessing import cpu_count
@@ -162,10 +156,6 @@ if __name__ == "__main__":
     level = logging.INFO
     InstallRootLoggingHandler(prefix, level=level, with_time=opts.verbose)
     root_logger = logging.getLogger()
-
-
-
-
 
     from Gaudi.Main import gaudimain
     c = gaudimain()

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -12,9 +12,9 @@ __filterGaudiProps = [ "ContextService", "Cardinality", "Context", "CounterList"
   "FilterCircularDependencies", "StatEntityList", "IsIOBound", "MonitorService", "NeededResources",
   "PropertiesPrint", "RegisterForContextService", "RegularRowFormat", "RequireObjects", "RootInTES",
   "StatPrint", "StatTableHeader", "Timeline", "TypePrint", "UseEfficiencyRowFormat",
-  "VetoObjects","OutputLevel",
-  "EnableFaultHandler" ,"InhibitPathes" ,"EnableAccessHandler" ,"ForceLeaves" ,"RootName"
-  ,"DataAccessName", "DataFaultName", "RootCLID"
+  "EnableFaultHandler", "InhibitPathes", "EnableAccessHandler", "ForceLeaves", "RootName",
+  "DataAccessName", "DataFaultName", "RootCLID", "PrintEmptyCounters", "Blocking",
+  "VetoObjects", "CheckToolDeps", "AutoRetrieveTools",
   ]
 
 #---------------------------------------------------------------------

--- a/test/k4TestFWCore/CMakeLists.txt
+++ b/test/k4TestFWCore/CMakeLists.txt
@@ -40,7 +40,7 @@ set_test_env(CreateExampleEventData)
 
 add_test(NAME TwoProducers
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-         COMMAND ${K4RUN} options/TwoProducer.py --filename output_k4fwcore_test_twoproducer2.root --magicNumberOffset.Producer2 12345 )
+         COMMAND ${K4RUN} options/TwoProducers.py --filename output_k4fwcore_test_twoproducer2.root --magicNumberOffset.Producer2 12345 --Producer1.magicNumberOffset 54321 )
 set_test_env(TwoProducers)
 
 add_test(NAME ReadExampleEventData

--- a/test/k4TestFWCore/CMakeLists.txt
+++ b/test/k4TestFWCore/CMakeLists.txt
@@ -38,6 +38,11 @@ add_test(NAME CreateExampleEventData
          COMMAND ${K4RUN} options/createExampleEventData.py)
 set_test_env(CreateExampleEventData)
 
+add_test(NAME TwoProducers
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+         COMMAND ${K4RUN} options/TwoProducer.py --filename output_k4fwcore_test_twoproducer2.root --magicNumberOffset.Producer2 12345 )
+set_test_env(TwoProducers)
+
 add_test(NAME ReadExampleEventData
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
          COMMAND ${K4RUN} options/readExampleEventData.py)

--- a/test/k4TestFWCore/options/TwoProducers.py
+++ b/test/k4TestFWCore/options/TwoProducers.py
@@ -1,0 +1,38 @@
+from Gaudi.Configuration import *
+
+from Configurables import ApplicationMgr
+ApplicationMgr(
+                EvtSel="NONE",
+                EvtMax=100,
+                OutputLevel=INFO,
+                StopOnSignal=True,
+                )
+
+
+from Configurables import k4DataSvc
+podioevent = k4DataSvc("EventDataSvc")
+ApplicationMgr().ExtSvc += [podioevent]
+
+from Configurables import CreateExampleEventData
+producer1 = CreateExampleEventData()
+ApplicationMgr().TopAlg += [producer1]
+
+
+from Configurables import CreateExampleEventData
+producer2 = CreateExampleEventData("Producer2")
+producer2.mcparticles.Path = "mcparticles2"
+producer2.trackhits.Path = "trackhits2"
+producer2.tracks.Path = "tracks2"
+producer2.singleint.Path = "singleint2"
+producer2.singlefloat.Path = "singlefloat2"
+producer2.vectorfloat.Path = "vectorfloat2"
+ApplicationMgr().TopAlg += [producer2]
+
+from Configurables import PodioOutput
+out = PodioOutput("out")
+out.filename = "output_k4test_exampledata_twoproducer.root"
+out.outputCommands = ["keep *"]
+ApplicationMgr().TopAlg += [producer2]
+
+
+

--- a/test/k4TestFWCore/options/TwoProducers.py
+++ b/test/k4TestFWCore/options/TwoProducers.py
@@ -22,6 +22,7 @@ from Configurables import CreateExampleEventData
 producer2 = CreateExampleEventData("Producer2")
 producer2.mcparticles.Path = "mcparticles2"
 producer2.trackhits.Path = "trackhits2"
+producer2.simtrackhits.Path = "simtrackhits2"
 producer2.tracks.Path = "tracks2"
 producer2.singleint.Path = "singleint2"
 producer2.singlefloat.Path = "singlefloat2"
@@ -32,7 +33,7 @@ from Configurables import PodioOutput
 out = PodioOutput("out")
 out.filename = "output_k4test_exampledata_twoproducer.root"
 out.outputCommands = ["keep *"]
-ApplicationMgr().TopAlg += [producer2]
+ApplicationMgr().TopAlg += [out]
 
 
 

--- a/test/k4TestFWCore/options/TwoProducers.py
+++ b/test/k4TestFWCore/options/TwoProducers.py
@@ -14,7 +14,7 @@ podioevent = k4DataSvc("EventDataSvc")
 ApplicationMgr().ExtSvc += [podioevent]
 
 from Configurables import CreateExampleEventData
-producer1 = CreateExampleEventData()
+producer1 = CreateExampleEventData("Producer1")
 ApplicationMgr().TopAlg += [producer1]
 
 

--- a/test/k4TestFWCore/options/createHelloWorld.py
+++ b/test/k4TestFWCore/options/createHelloWorld.py
@@ -1,13 +1,18 @@
 from Gaudi.Configuration import *
 
+from Configurables import ApplicationMgr
+ApplicationMgr().EvtSel = "NONE"
+ApplicationMgr().EvtMax = 1           
+ApplicationMgr().OutputLevel = INFO
+
 from Configurables import HelloWorldAlg
 producer = HelloWorldAlg()
 producer.PerEventPrintMessage = "Hello World !"
+ApplicationMgr().TopAlg += [producer]
 
-from Configurables import ApplicationMgr
-ApplicationMgr( TopAlg=[producer],
-                EvtSel="NONE",
-                EvtMax=1,                
-                OutputLevel=INFO,
-                )
+from Configurables import HelloWorldAlg
+producer2 = HelloWorldAlg()
+producer2.PerEventPrintMessage = "Hello World2 !"
+ApplicationMgr().TopAlg += [producer2]
+
 

--- a/test/k4TestFWCore/src/components/CreateExampleEventData.cpp
+++ b/test/k4TestFWCore/src/components/CreateExampleEventData.cpp
@@ -12,7 +12,8 @@ DECLARE_COMPONENT(CreateExampleEventData)
 
 CreateExampleEventData::CreateExampleEventData(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {
   declareProperty("mcparticles", m_mcParticleHandle, "Dummy Particle collection (output)");
-  declareProperty("trackhits", m_simTrackerHitHandle, "Dummy Hit collection (output)");
+  declareProperty("simtrackhits", m_simTrackerHitHandle, "Dummy Hit collection (output)");
+  declareProperty("trackhits", m_TrackerHitHandle, "Dummy Hit collection (output)");
   declareProperty("tracks", m_trackHandle, "Dummy track collection (output)");
   declareProperty("singlefloat", m_singleFloatHandle, "Dummy collection (output)");
   declareProperty("vectorfloat", m_vectorFloatHandle, "Dummy collection (output)");

--- a/test/k4TestFWCore/src/components/CreateExampleEventData.cpp
+++ b/test/k4TestFWCore/src/components/CreateExampleEventData.cpp
@@ -14,6 +14,9 @@ CreateExampleEventData::CreateExampleEventData(const std::string& aName, ISvcLoc
   declareProperty("mcparticles", m_mcParticleHandle, "Dummy Particle collection (output)");
   declareProperty("trackhits", m_simTrackerHitHandle, "Dummy Hit collection (output)");
   declareProperty("tracks", m_trackHandle, "Dummy track collection (output)");
+  declareProperty("singlefloat", m_singleFloatHandle, "Dummy collection (output)");
+  declareProperty("vectorfloat", m_vectorFloatHandle, "Dummy collection (output)");
+  declareProperty("singleint", m_singleIntHandle, "Dummy collection (output)");
 }
 
 CreateExampleEventData::~CreateExampleEventData() {}


### PR DESCRIPTION
See discussion in #38 

The "shortcuts" are more tricky to work with than the full property names - if there are two shortcuts with the same name, the order of the configurables in the options file determines which one gets set by the shortcut. So where brevity is not important, it's probably better to use `--PodioOutput.filename` instead of `--filename`, for example. Still, as sometimes these will get typed, I think it's good to have.

BEGINRELEASENOTES
- add property arguments shortcuts where possible.

ENDRELEASENOTES
