### PR TITLE
[k4run] ensure no duplicates are in the list of configurables

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -70,7 +70,7 @@ if __name__ == "__main__":
       option_db = {}
 
       # loop over all components that were configured in the options file
-      for conf in list(ApplicationMgr.allConfigurables.values()):
+      for conf in set(list(ApplicationMgr.allConfigurables.values())):
         # skip public tools and the applicationmgr itself
         if "ToolSvc" not in conf.name() and "ApplicationMgr" not in conf.name():
           props = conf.getPropertiesWithDescription() #dict propertyname: (propertyvalue, propertydescription)


### PR DESCRIPTION
With some job configurations, some tools are part of this list twice, and then raise an argumenterror when k4run tries to add their properties as command line arguments
