### PR TITLE
[k4run] print out paths to configurables when running `k4run --list`

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -117,7 +117,11 @@ if __name__ == "__main__":
         print("Available components:\n%s" % (21 * "="))
         for item in sorted(cfgDb):
             if True: # another option could filter Gaudi components here
-              print("  %s (from %s)" % (item, cfgDb[item]["lib"]))
+              try:
+                path_to_component = __import__(cfgDb[item]["module"]).__file__
+              except ImportError:
+                path_to_component = "NotFound"
+              print("  %s (from %s), \n\t\t path: %s\n" % (item, cfgDb[item]["lib"], path_to_component))
             else:
                 if not "Gaudi" in cfgDb[item]["lib"]:
                   print("  %s (from %s)" % (item, cfgDb[item]["lib"]))


### PR DESCRIPTION
As requested by @BrieucF. Note that this shows the path to the generated python configurable, the C++ code is loaded via LD_LIBRARY_PATH

BEGINRELEASENOTES
-  k4run:  print out paths to configurables with --list (Note that this shows the path to the generated python configurable, the C++ code is loaded via LD_LIBRARY_PATH)
ENDRELEASENOTES

