### PR TITLE
use own registerObject when reading collection

### DIFF
--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -109,7 +109,7 @@ StatusCode PodioDataSvc::readCollection(const std::string& collName, int collect
   collection->prepareAfterRead();
   wrapper->setData(collection);
   m_readCollections.emplace_back(std::make_pair(collName, collection));
-  return DataSvc::registerObject("/Event", "/" + collName, wrapper);
+  return registerObject("/Event", "/" + collName, wrapper);
 }
 
 StatusCode PodioDataSvc::registerObject(std::string_view parentPath, std::string_view fullPath, DataObject* pObject) {


### PR DESCRIPTION
BEGINRELEASENOTES
- After reading with PodioInput, collections are not available even if they were being registered. Wrong `registerObject` was being called.
ENDRELEASENOTES
