### PR TITLE
Add dev3 and dev4 CI workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        SETUP: ['/cvmfs/sw.hsf.org/key4hep/setup.sh', '/cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh', '/cvmfs/sft.cern.ch/lcg/views/LCG_99/x86_64-centos7-gcc8-opt/setup.sh']
+        cvmfs_base: ['sft.cern.ch/lcg/views']
+        ENVIRONMENT: ['LCG_99/x86_64-centos7-gcc8-opt',
+                      'dev3/latest/x86_64-centos7-gcc10-opt',
+                      'dev4/latest/x86_64-centos7-clang11-opt']
+        include:
+        - cvmfs_base: 'sw.hsf.org'
+          ENVIRONMENT: 'key4hep'
+        - cvmfs_base: 'sw-nightlies.hsf.org'
+          ENVIRONMENT: 'key4hep'
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2
@@ -20,27 +28,26 @@ jobs:
         docker exec CI_container /bin/bash -c " ln -s /usr/lib64/liblzma.so.5.2.2 /usr/lib64/liblzma.so;"
     - name: CMake Configure
       run: |
-        docker exec CI_container /bin/bash -c 'cd Package;\
+         docker exec CI_container /bin/bash -c 'cd Package;\
          mkdir -p build install;\
-         source ${{ matrix.SETUP }};\
+         source /cvmfs/${{ matrix.cvmfs_base }}/${{ matrix.ENVIRONMENT }}/setup.sh;\
          cd build;\
          cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_CXX_STANDARD=17  -DCMAKE_CXX_FLAGS=" -fdiagnostics-color=always " -G Ninja ..;'
-    - name: Compile 
+    - name: Compile
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
-        source ${{ matrix.SETUP }};\
+        source /cvmfs/${{ matrix.cvmfs_base }}/${{ matrix.ENVIRONMENT }}/setup.sh;\
         cd build;\
         ninja -k0;'
-    - name: Install
-      run: |
-        docker exec CI_container /bin/bash -c 'cd ./Package;\
-          source ${{ matrix.SETUP }};\
-          cd build;\
-          ninja -k0 install;'
     - name: Test
       run: |
         docker exec CI_container /bin/bash -c 'cd ./Package;\
-        source ${{ matrix.SETUP }};\
+        source /cvmfs/${{ matrix.cvmfs_base }}/${{ matrix.ENVIRONMENT }}/setup.sh;\
         cd build;\
         ninja -k0 && ctest --output-on-failure;'
-
+    - name: Install
+      run: |
+        docker exec CI_container /bin/bash -c 'cd ./Package;\
+        source /cvmfs/${{ matrix.cvmfs_base }}/${{ matrix.ENVIRONMENT }}/setup.sh;\
+        cd build;\
+        ninja -k0 install;'


### PR DESCRIPTION
BEGINRELEASENOTES
- Add dev3 and dev4 CI workflows

ENDRELEASENOTES

With dev3 we get Gaudis master branch, which might give us a heads-up if things are changing (see, e.g. #58). Maybe make the devX workflows to not be required for PRs