### PR TITLE
Propagate CollectionBuffer changes from  https://github.com/AIDASoft/podio/pull/197

### DIFF
--- a/k4FWCore/components/PodioOutput.h
+++ b/k4FWCore/components/PodioOutput.h
@@ -49,6 +49,10 @@ private:
   TTree* m_datatree;
   /// The tree to be filled with meta data
   TTree* m_metadatatree;
+  TTree* m_runMDtree;
+  TTree* m_evtMDtree;
+  TTree* m_colMDtree;
+
   /// The stored collections
   std::vector<podio::CollectionBase*> m_storedCollections;
 };

--- a/k4FWCore/components/rootUtils.h
+++ b/k4FWCore/components/rootUtils.h
@@ -1,0 +1,52 @@
+#ifndef PODIO_ROOT_UTILS_H
+#define PODIO_ROOT_UTILS_H
+
+#include "podio/CollectionBase.h"
+#include "podio/CollectionBranches.h"
+
+#include "TBranch.h"
+#include "TClass.h"
+
+#include <vector>
+#include <string>
+
+namespace podio::root_utils {
+// Workaround slow branch retrieval for 6.22/06 performance degradation
+// see: https://root-forum.cern.ch/t/serious-degradation-of-i-o-performance-from-6-20-04-to-6-22-06/43584/10
+template<class Tree>
+TBranch* getBranch(Tree* chain, const char* name) {
+  return static_cast<TBranch*>(chain->GetListOfBranches()->FindObject(name));
+}
+
+inline std::string refBranch(const std::string& name, size_t index) {
+  return name + "#" + std::to_string(index);
+}
+
+inline std::string vecBranch(const std::string& name, size_t index) {
+  return name + "_" + std::to_string(index);
+}
+
+
+inline void setCollectionAddresses(podio::CollectionBase* collection, const CollectionBranches& branches) {
+  const auto collBuffers = collection->getBuffers();
+
+  if (auto buffer = collBuffers.data) {
+    branches.data->SetAddress(buffer);
+  }
+
+  if (auto refCollections = collBuffers.references) {
+    for (size_t i = 0; i < refCollections->size(); ++i) {
+      branches.refs[i]->SetAddress(&(*refCollections)[i]);
+    }
+  }
+
+  if (auto vecMembers = collBuffers.vectorMembers) {
+    for (size_t i = 0; i < vecMembers->size(); ++i) {
+      branches.vecs[i]->SetAddress((*vecMembers)[i].second);
+    }
+  }
+}
+
+}
+
+#endif

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -43,7 +43,7 @@ public:
 
   virtual const CollRegistry& getCollections() const { return m_collections; }
   virtual const CollRegistry& getReadCollections() const { return m_readCollections; }
-  const podio::EventStore& getProvider() const { return m_provider; }
+  podio::EventStore& getProvider() { return m_provider; }
   virtual podio::CollectionIDTable* getCollectionIDs() { return m_collectionIDs; }
 
   /// Set the collection IDs (if reading a file)

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -7,6 +7,8 @@
 
 #include "TTree.h"
 
+#include "edm4hep/MCParticleCollection.h"
+
 /// Service initialisation
 StatusCode PodioDataSvc::initialize() {
   // Nothing to do: just call base class initialisation
@@ -26,10 +28,13 @@ StatusCode PodioDataSvc::initialize() {
     if (m_filenames[0] != "") {
       m_reader.openFiles(m_filenames);
       m_eventMax = m_reader.getEntries();
-      auto idTable = m_reader.getCollectionIDTable();
 
-      setCollectionIDs(idTable);
       m_provider.setReader(&m_reader);
+
+      auto idTable = m_provider.getCollectionIDTable();
+      idTable->print();
+      setCollectionIDs(idTable);
+      idTable->print();
 
       if (m_1stEvtEntry != 0 ) {
           m_reader.goToEvent(m_1stEvtEntry);
@@ -102,14 +107,21 @@ PodioDataSvc::~PodioDataSvc() {}
 
 StatusCode PodioDataSvc::readCollection(const std::string& collName, int collectionID) {
   podio::CollectionBase* collection(nullptr);
+
+      auto idTable = m_provider.getCollectionIDTable();
+      idTable->print();
   m_provider.get(collectionID, collection);
+
+  if (collection->isSubsetCollection()) {
+    return StatusCode::SUCCESS;
+  }
   auto wrapper = new DataWrapper<podio::CollectionBase>;
   int id = m_collectionIDs->add(collName);
   collection->setID(id);
   collection->prepareAfterRead();
   wrapper->setData(collection);
   m_readCollections.emplace_back(std::make_pair(collName, collection));
-  return DataSvc::registerObject("/Event", "/" + collName, wrapper);
+  return registerObject("/Event", "/" + collName, wrapper);
 }
 
 StatusCode PodioDataSvc::registerObject(std::string_view parentPath, std::string_view fullPath, DataObject* pObject) {

--- a/test/k4FWCoreTest/options/readExampleEventData.py
+++ b/test/k4FWCoreTest/options/readExampleEventData.py
@@ -6,7 +6,7 @@ podioevent.input = "output_k4test_exampledata.root"
 
 from Configurables import PodioInput
 inp = PodioInput()
-inp.collections = ["MCParticles", "SimTrackerHits", "Tracks"]
+inp.collections = ["MCParticles", "SimTrackerHits", "TrackerHits", "Tracks"]
 
 from Configurables import PodioOutput
 oup = PodioOutput()
@@ -16,7 +16,7 @@ oup.outputCommands = ["drop MCParticles"]
 from Configurables import ApplicationMgr
 ApplicationMgr( TopAlg=[inp, oup],
                 EvtSel="NONE",
-                EvtMax=100,
+                EvtMax=10,
                 ExtSvc=[podioevent],
                 OutputLevel=DEBUG,
                 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Propagate CollectionBuffer changes from  https://github.com/AIDASoft/podio/pull/197

ENDRELEASENOTES

Currently, these are only the minimal syntax changes. Since the PodioDataSvc does not use the ROOTWriter at the moment (due to the I/O of basic types not supported yet) either the changes from  https://github.com/AIDASoft/podio/pull/197 must be ported here, or we wait for 
https://github.com/AIDASoft/podio/pull/213 and then refactor to use the ROOTWriter.

I prefer the second option (also because simply adding the ROOTWriter changes here still produced a segfault that would need to be debugged).