### PR TITLE
Remove track keeping of read collections

### DIFF
--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -128,10 +128,8 @@ StatusCode PodioOutput::execute() {
   // register for writing
   if (m_firstEvent) {
     createBranches(m_podioDataSvc->getCollections());
-    //createBranches(m_podioDataSvc->getReadCollections());
   } else {
     resetBranches(m_podioDataSvc->getCollections());
-    //resetBranches(m_podioDataSvc->getReadCollections());
   }
   m_firstEvent = false;
   debug() << "Filling DataTree .." << endmsg;

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -42,7 +42,6 @@ public:
   StatusCode readCollection(const std::string& collectionName, int collectionID);
 
   virtual const CollRegistry& getCollections() const { return m_collections; }
-  virtual const CollRegistry& getReadCollections() const { return m_readCollections; }
   podio::EventStore& getProvider() { return m_provider; }
   virtual podio::CollectionIDTable* getCollectionIDs() { return m_collectionIDs; }
 
@@ -73,7 +72,6 @@ private:
 
   // special members for podio handling
   std::vector<std::pair<std::string, podio::CollectionBase*>> m_collections;
-  std::vector<std::pair<std::string, podio::CollectionBase*>> m_readCollections;
   podio::CollectionIDTable* m_collectionIDs;
 
 protected:

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -60,14 +60,8 @@ StatusCode PodioDataSvc::clearStore() {
       collNamePair.second->clear();
     }
   }
-  for (auto& collNamePair : m_readCollections) {
-    if (collNamePair.second != nullptr) {
-      collNamePair.second->clear();
-    }
-  }
   DataSvc::clearStore().ignore();
   m_collections.clear();
-  m_readCollections.clear();
   return StatusCode::SUCCESS;
 }
 
@@ -117,7 +111,6 @@ StatusCode PodioDataSvc::readCollection(const std::string& collName, int collect
   collection->setID(id);
   collection->prepareAfterRead();
   wrapper->setData(collection);
-  m_readCollections.emplace_back(std::make_pair(collName, collection));
   return registerObject("/Event", "/" + collName, wrapper);
 }
 


### PR DESCRIPTION


BEGINRELEASENOTES
- Remove the no longer necessary track keeping of collections that have been read from an input file, since these are now handled correctly by podio as well (Since AIDASoft/podio#144)

ENDRELEASENOTES
