### PR TITLE
Adapt to new podio generated class names

### DIFF
--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -56,8 +56,8 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute() {
   trackerHit.setPosition({3, 4, 5});
 
   edm4hep::TrackCollection* tracks = m_trackHandle.createAndPut();
-  edm4hep::Track track = tracks->create();
-  edm4hep::Track track2 = tracks->create();
+  auto track = tracks->create();
+  auto track2 = tracks->create();
   // set members
   track.setType(1);
   track.setChi2(2.1);


### PR DESCRIPTION
BEGINRELEASENOTES
- Replace a few dedicated types with `auto` to trivially adapt to the new naming scheme introduced in AIDASoft/podio#205.
  - The necessary changes in EDM4hep: key4hep/EDM4hep#132 would break this otherwise. The changes make this work with either version of EDM4hep.

ENDRELEASENOTES