### PR TITLE
Fix a deprecation warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         cvmfs_base: ['sft.cern.ch/lcg/views']
-        ENVIRONMENT: ['LCG_102rc1/x86_64-centos7-gcc11-opt',
-                      'dev3/latest/x86_64-centos7-gcc10-opt',
+        ENVIRONMENT: ['dev3/latest/x86_64-centos7-gcc10-opt',
                       ]
         include:
         - cvmfs_base: 'sw.hsf.org'

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -193,7 +193,7 @@ const std::string DataHandle<T>::getCollMetadataCellID(
 
   if (pds != nullptr) {
     auto colMD = pds->getProvider().getCollectionMetaData( id );
-    return colMD.getStringVal("CellIDEncodingString") ;
+    return colMD.getValue<std::string>("CellIDEncodingString") ;
   } else {
     std::string msg("Could not get Podio Data Service.");
     throw GaudiException(msg, "Failed to get Collection Metadata.", StatusCode::FAILURE);

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -177,6 +177,7 @@ template <typename T> const std::string DataHandle<T>::getCollMetadataCellID(con
   pds = dynamic_cast<PodioDataSvc*>(m_eds.get());
 
   if (pds != nullptr) {
+    auto colMD = pds->getProvider().getCollectionMetaData(id);
     return colMD.getValue<std::string>("CellIDEncodingString");
   } else {
     std::string msg("Could not get Podio Data Service.");


### PR DESCRIPTION
BEGINRELEASENOTES

- Use the new templated getters, fixes compiler warnings

ENDRELEASENOTES

The non-templated getters were deprecated in https://github.com/AIDASoft/podio/pull/262