### PR TITLE
Improvements to k4run

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -76,13 +76,11 @@ if __name__ == "__main__":
     # ensure that we (and the subprocesses) use the C standard localization
     os.environ['LC_ALL'] = 'C'
 
-    logger = logging.getLogger(__name__)
+    logger = logging.getLogger()
     logger.setLevel(logging.INFO)
-    # Don't propagate to the root logger, otherwise the output will be doubled
-    logger.propagate = 0
     # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
     formatter = logging.Formatter('[k4run] %(message)s')
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(stream=sys.stdout)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
@@ -116,7 +114,7 @@ if __name__ == "__main__":
     opts = parser.parse_args()
 
     # print a doc line showing the configured algorithms
-    logger.info('-->' + ' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
+    logger.info('--> ' + ' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
 
     if opts.list:
         from Gaudi import Configuration
@@ -155,14 +153,6 @@ if __name__ == "__main__":
         elif opts.ncpus < -1:
             s = "Invalid value : --ncpus must be integer >= -1"
             parser.error(s)
-
-    # configure the logging
-    from GaudiKernel.ProcessJobOptions import InstallRootLoggingHandler
-
-    prefix = "# "
-    level = logging.INFO
-    InstallRootLoggingHandler(prefix, level=level, with_time=opts.verbose)
-    root_logger = logging.getLogger()
 
     from Gaudi.Main import gaudimain
     c = gaudimain()

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -116,12 +116,12 @@ if __name__ == "__main__":
     opts = parser.parse_args()
 
     # print a doc line showing the configured algorithms
-    logger.info(' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
+    logger.info('-->' + ' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
 
     if opts.list:
         from Gaudi import Configuration
         cfgDb = Configuration.cfgDb
-        logger.info("Available components:\n%s" % (21 * "="))
+        logger.info("Available components:\n%s", (21 * "="))
         for item in sorted(cfgDb):
             if True:  # another option could filter Gaudi components here
               try:
@@ -136,7 +136,7 @@ if __name__ == "__main__":
 
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
-      logger.info("Option name: " + str(propTuple[1]) + " " + optionName + " " + str(opts_dict[optionName]))
+      logger.info("Option name: %s %s %s", propTuple[1], optionName, opts_dict[optionName])
       propTuple[0].setProp(propTuple[1].rsplit(".",1)[1], opts_dict[optionName])
 
     if opts.verbose:

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -4,6 +4,8 @@ from __future__ import print_function
 import os
 import sys
 import argparse
+from multiprocessing import cpu_count
+import logging
 
 
 # these default properties are filtered as otherwise they will clutter the argument list
@@ -55,10 +57,9 @@ if __name__ == "__main__":
     #   -1   : All available cpus
     #    0   : Serial Mode (traditional gaudirun)
     #    n>0 : parallel with n cpus (n <= sys_cpus)
-    parser.add_argument("--ncpus",  type=int, default=0,
+    parser.add_argument("--ncpus", type=int, default=0,
                       help="Start Gaudi in parallel mode using NCPUS processes. "
                            "0 => serial mode (default), -1 => use all CPUs")
-
 
 
     # print a doc line showing the configured algorithms
@@ -68,48 +69,46 @@ if __name__ == "__main__":
       print("",'\n')
 
       option_db = {}
-
       # loop over all components that were configured in the options file
-      for conf in set(list(ApplicationMgr.allConfigurables.values())):
+      for conf in dict.fromkeys(ApplicationMgr.allConfigurables.values()):
         # skip public tools and the applicationmgr itself
-        if "ToolSvc" not in conf.name() and "ApplicationMgr" not in conf.name():
-          props = conf.getPropertiesWithDescription() #dict propertyname: (propertyvalue, propertydescription)
-          for prop in props:
-            # only add arguments for relevant properties
-            if not prop in __filterGaudiProps:
-              if not "Audit" in prop:
-                # do not want to deal with other components / datahandles for now
-                  if not hasattr(props[prop][0], '__slots__'):
-                    propvalue = props[prop][0]
+        if "ToolSvc" in conf.name() or "ApplicationMgr" in conf.name():
+          continue
+        props = conf.getPropertiesWithDescription() #dict propertyname: (propertyvalue, propertydescription)
+        for prop in props:
+          # only add arguments for relevant properties
+          if prop in __filterGaudiProps or "Audit" in prop or hasattr(props[prop][0], '__slots__'):
+            continue
+          propvalue = props[prop][0]
 
-                    # if it is set to "no value" it hasn't been touched in the options file
+          # if it is set to "no value" it hasn't been touched in the options file
 
-                    if propvalue == conf.propertyNoValue:
-                       propvalue = conf.getDefaultProperty(prop) # thus get the default value
-                    proptype = type(props[prop][0])
-                    # if the property is a list of something, we need to set argparse nargs to '+'
-                    propnargs = "?"
-                    if proptype == list:
-                      # tricky edgecase: if the default is an empty list there is no way to get the type
-                      if len(propvalue) == 0:
-                        # just skip for now
-                        #print("Warning: argparse cannot deduce type for property %s of %s. Needs to be set in options file." % (prop, conf.name()))
-                        continue
-                      else:
-                        # deduce type from first item of the list
-                        proptype = type(propvalue[0])
-                      propnargs = "+"
+          if propvalue == conf.propertyNoValue:
+              propvalue = conf.getDefaultProperty(prop) # thus get the default value
+          proptype = type(props[prop][0])
+          # if the property is a list of something, we need to set argparse nargs to '+'
+          propnargs = "?"
+          if proptype == list:
+              # tricky edgecase: if the default is an empty list there is no way to get the type
+              if len(propvalue) == 0:
+              # just skip for now
+              #print("Warning: argparse cannot deduce type for property %s of %s. Needs to be set in options file." % (prop, conf.name()))
+                continue
+              else:
+                # deduce type from first item of the list
+                proptype = type(propvalue[0])
+              propnargs = "+"
 
-                    # add the argument twice, once as "--PodioOutput.filename"
-                    # and once as "--filename.PodioOutput"
-                    propName = conf.name() + '.' + prop
-                    propNameReversed = prop + '.' + conf.name()
-                    option_db[propName] = (conf, propName)
-                    parser.add_argument( "--%s" % propName, "--%s" % propNameReversed, type=proptype, help=props[prop][1],
-                      nargs=propnargs,
-                      default=propvalue)
+          # add the argument twice, once as "--PodioOutput.filename"
+          # and once as "--filename.PodioOutput"
+          propName = conf.name() + '.' + prop
+          propNameReversed = prop + '.' + conf.name()
+          option_db[propName] = (conf, propName)
+          parser.add_argument( "--%s" % propName, "--%s" % propNameReversed, type=proptype, help=props[prop][1],
+              nargs=propnargs,
+              default=propvalue)
 
-    opts=parser.parse_args()
+    opts = parser.parse_args()
 
     if opts.list:
         from Gaudi import Configuration
@@ -145,7 +144,6 @@ if __name__ == "__main__":
 
     # Parallel Option ---------------------------------------------------------
     if opts.ncpus:
-        from multiprocessing import cpu_count
         sys_cpus = cpu_count()
         if opts.ncpus > sys_cpus:
             s = "Invalid value : --ncpus : only %i cpus available" % sys_cpus
@@ -155,9 +153,7 @@ if __name__ == "__main__":
             parser.error(s)
 
     # configure the logging
-    import logging
-    from GaudiKernel.ProcessJobOptions import (InstallRootLoggingHandler,
-                                               PrintOff)
+    from GaudiKernel.ProcessJobOptions import InstallRootLoggingHandler, PrintOff
 
     prefix = "# "
     level = logging.INFO

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -22,8 +22,17 @@ __filterGaudiProps = [ "ContextService", "Cardinality", "Context", "CounterList"
 #---------------------------------------------------------------------
 if __name__ == "__main__":
     # ensure that we (and the subprocesses) use the C standard localization
-    if os.environ.get('LC_ALL') != 'C':
-        os.environ['LC_ALL'] = 'C'
+    os.environ['LC_ALL'] = 'C'
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    # Don't propagate to the root logger, otherwise the output will be doubled
+    logger.propagate = 0
+    # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
+    formatter = logging.Formatter('[k4run] %(message)s')
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
     # run all the configuration files
     # we generate arguments from them, so we need to load them
@@ -40,15 +49,15 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Run job in the Key4HEP framework")
     parser.add_argument("config_files", nargs="*",
-                      help="Gaudi config (python) files describing the job")
+                        help="Gaudi config (python) files describing the job")
     parser.add_argument("--dry-run", action="store_true",
-                      help="Do not actually run the job, just parse the config files")
+                        help="Do not actually run the job, just parse the config files")
     parser.add_argument("-v", "--verbose", action="store_true",
-                      help="Run job with verbose output")
+                        help="Run job with verbose output")
     parser.add_argument("-n", "--num-events", type=int,
-                      help="Number of events to run")
+                        help="Number of events to run")
     parser.add_argument("-l", "--list", action="store_true",
-                      help="Print all the configurable components available in the framework and exit")
+                        help="Print all the configurable components available in the framework and exit")
     parser.add_argument("--gdb", action="store_true", help="Attach gdb debugger")
 
     # TODO: Don't want to advertise this until tested.
@@ -64,12 +73,11 @@ if __name__ == "__main__":
 
     # print a doc line showing the configured algorithms
     if run_with_options_file:
-      for alg in ApplicationMgr().TopAlg:
-        print(' --> ', alg.name(), end='')
-      print("",'\n')
+      logger.info(' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
 
       option_db = {}
       # loop over all components that were configured in the options file
+      # use dict.fromkeys so that the confs are sorted (Python >= 3.7)
       for conf in dict.fromkeys(ApplicationMgr.allConfigurables.values()):
         # skip public tools and the applicationmgr itself
         if "ToolSvc" in conf.name() or "ApplicationMgr" in conf.name():
@@ -82,7 +90,6 @@ if __name__ == "__main__":
           propvalue = props[prop][0]
 
           # if it is set to "no value" it hasn't been touched in the options file
-
           if propvalue == conf.propertyNoValue:
               propvalue = conf.getDefaultProperty(prop) # thus get the default value
           proptype = type(props[prop][0])
@@ -113,7 +120,7 @@ if __name__ == "__main__":
     if opts.list:
         from Gaudi import Configuration
         cfgDb = Configuration.cfgDb
-        print("Available components:\n%s" % (21 * "="))
+        logger.info("Available components:\n%s" % (21 * "="))
         for item in sorted(cfgDb):
             if True: # another option could filter Gaudi components here
               try:
@@ -127,12 +134,12 @@ if __name__ == "__main__":
         sys.exit()
 
     if not run_with_options_file:
-      print("usage: " + os.path.basename(__file__) + " [gaudi_config.py ...] Specify a gaudi options file to run")
+      logging.error("usage: " + os.path.basename(__file__) + " [gaudi_config.py ...] Specify a gaudi options file to run")
       sys.exit()
 
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
-      print("Option name:", propTuple[1], optionName, opts_dict[optionName])
+      logger.info("Option name: " + str(propTuple[1]) + " " + optionName + " " + str(opts_dict[optionName]))
       propTuple[0].setProp(propTuple[1].rsplit(".",1)[1], opts_dict[optionName])
 
     if opts.verbose:
@@ -153,7 +160,7 @@ if __name__ == "__main__":
             parser.error(s)
 
     # configure the logging
-    from GaudiKernel.ProcessJobOptions import InstallRootLoggingHandler, PrintOff
+    from GaudiKernel.ProcessJobOptions import InstallRootLoggingHandler
 
     prefix = "# "
     level = logging.INFO

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     opts = parser.parse_args()
 
     # print a doc line showing the configured algorithms
-    logger.info('--> ' + ' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
+    logger.info(' '.join(f'--> {alg.name()}' for alg in ApplicationMgr().TopAlg))
 
     if opts.list:
         from Gaudi import Configuration

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -9,7 +9,7 @@ import logging
 
 
 # these default properties are filtered as otherwise they will clutter the argument list
-__filterGaudiProps = [ "ContextService", "Cardinality", "Context", "CounterList", "EfficiencyRowFormat",
+FILTER_GAUDI_PROPS = [ "ContextService", "Cardinality", "Context", "CounterList", "EfficiencyRowFormat",
   "Enable", "ErrorCount", "ErrorMax", "ErrorsPrint", "ExtraInputs", "ExtraOutputs",
   "FilterCircularDependencies", "StatEntityList", "IsIOBound", "MonitorService", "NeededResources",
   "PropertiesPrint", "RegisterForContextService", "RegularRowFormat", "RequireObjects", "RootInTES",
@@ -20,62 +20,16 @@ __filterGaudiProps = [ "ContextService", "Cardinality", "Context", "CounterList"
   ]
 
 #---------------------------------------------------------------------
-if __name__ == "__main__":
-    # ensure that we (and the subprocesses) use the C standard localization
-    os.environ['LC_ALL'] = 'C'
 
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
-    # Don't propagate to the root logger, otherwise the output will be doubled
-    logger.propagate = 0
-    # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
-    formatter = logging.Formatter('[k4run] %(message)s')
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
-    # run all the configuration files
-    # we generate arguments from them, so we need to load them
-    # before parsing the arguments
-    # to avoid parsing them twice, just assume the positional arguments
-    # come first and as soon as we encounter "-" we stop
-    run_with_options_file = False
-    for f in sys.argv[1:]:
-      if f[0] != '-':
-        exec(open(f).read())
-        run_with_options_file = True
-      else:
-        break
-
-    parser = argparse.ArgumentParser(description="Run job in the Key4HEP framework")
-    parser.add_argument("config_files", nargs="*",
-                        help="Gaudi config (python) files describing the job")
-    parser.add_argument("--dry-run", action="store_true",
-                        help="Do not actually run the job, just parse the config files")
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Run job with verbose output")
-    parser.add_argument("-n", "--num-events", type=int,
-                        help="Number of events to run")
-    parser.add_argument("-l", "--list", action="store_true",
-                        help="Print all the configurable components available in the framework and exit")
-    parser.add_argument("--gdb", action="store_true", help="Attach gdb debugger")
-
-    # TODO: Don't want to advertise this until tested.
-    # GaudiPython Parallel Mode Option
-    #   Argument must be an integer in range [ -1, sys_cpus ]
-    #   -1   : All available cpus
-    #    0   : Serial Mode (traditional gaudirun)
-    #    n>0 : parallel with n cpus (n <= sys_cpus)
-    parser.add_argument("--ncpus", type=int, default=0,
-                      help="Start Gaudi in parallel mode using NCPUS processes. "
-                           "0 => serial mode (default), -1 => use all CPUs")
-
-
-    # print a doc line showing the configured algorithms
-    if run_with_options_file:
-      logger.info(' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
-
-      option_db = {}
+seen_files = set()
+option_db = {}
+class LoadFromFile(argparse.Action):
+    def __call__ (self, parser, namespace, values, option_string=None):
+      for wrapper in values:
+        if wrapper.name in seen_files:
+            return
+        seen_files.add(wrapper.name)
+        exec(open(wrapper.name).read(), globals())
       # loop over all components that were configured in the options file
       # use dict.fromkeys so that the confs are sorted (Python >= 3.7)
       for conf in dict.fromkeys(ApplicationMgr.allConfigurables.values()):
@@ -85,7 +39,7 @@ if __name__ == "__main__":
         props = conf.getPropertiesWithDescription() #dict propertyname: (propertyvalue, propertydescription)
         for prop in props:
           # only add arguments for relevant properties
-          if prop in __filterGaudiProps or "Audit" in prop or hasattr(props[prop][0], '__slots__'):
+          if prop in FILTER_GAUDI_PROPS or "Audit" in prop or hasattr(props[prop][0], '__slots__'):
             continue
           propvalue = props[prop][0]
 
@@ -115,7 +69,51 @@ if __name__ == "__main__":
               nargs=propnargs,
               default=propvalue)
 
+if __name__ == "__main__":
+    # ensure that we (and the subprocesses) use the C standard localization
+    os.environ['LC_ALL'] = 'C'
+
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+    # Don't propagate to the root logger, otherwise the output will be doubled
+    logger.propagate = 0
+    # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
+    formatter = logging.Formatter('[k4run] %(message)s')
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    parser = argparse.ArgumentParser(description="Run job in the Key4HEP framework")
+    parser.add_argument("config_files", type=open, action=LoadFromFile, nargs="*",
+                        help="Gaudi config (python) files describing the job")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Do not actually run the job, just parse the config files")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Run job with verbose output")
+    parser.add_argument("-n", "--num-events", type=int,
+                        help="Number of events to run")
+    parser.add_argument("-l", "--list", action="store_true",
+                        help="Print all the configurable components available in the framework and exit")
+    parser.add_argument("--gdb", action="store_true", help="Attach gdb debugger")
+
+    # TODO: Don't want to advertise this until tested.
+    # GaudiPython Parallel Mode Option
+    #   Argument must be an integer in range [ -1, sys_cpus ]
+    #   -1   : All available cpus
+    #    0   : Serial Mode (traditional gaudirun)
+    #    n>0 : parallel with n cpus (n <= sys_cpus)
+    parser.add_argument("--ncpus", type=int, default=0,
+                      help="Start Gaudi in parallel mode using NCPUS processes. "
+                           "0 => serial mode (default), -1 => use all CPUs")
+
+    # Once to parse the files and another time to have the new parameters
+    # in the namespace since parsing of the file happens when the namespace
+    # has already been filled
     opts = parser.parse_args()
+    opts = parser.parse_args()
+
+    # print a doc line showing the configured algorithms
+    logger.info(' --> '.join([alg.name() for alg in ApplicationMgr().TopAlg]))
 
     if opts.list:
         from Gaudi import Configuration
@@ -132,10 +130,6 @@ if __name__ == "__main__":
                 if not "Gaudi" in cfgDb[item]["lib"]:
                   print("  %s (from %s)" % (item, cfgDb[item]["lib"]))
         sys.exit()
-
-    if not run_with_options_file:
-      logging.error("usage: " + os.path.basename(__file__) + " [gaudi_config.py ...] Specify a gaudi options file to run")
-      sys.exit()
 
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -23,8 +23,10 @@ FILTER_GAUDI_PROPS = [ "ContextService", "Cardinality", "Context", "CounterList"
 
 seen_files = set()
 option_db = {}
+
+
 class LoadFromFile(argparse.Action):
-    def __call__ (self, parser, namespace, values, option_string=None):
+    def __call__(self, parser, namespace, values, option_string=None):
       for wrapper in values:
         if wrapper.name in seen_files:
             return
@@ -69,6 +71,7 @@ class LoadFromFile(argparse.Action):
               nargs=propnargs,
               default=propvalue)
 
+
 if __name__ == "__main__":
     # ensure that we (and the subprocesses) use the C standard localization
     os.environ['LC_ALL'] = 'C'
@@ -103,13 +106,13 @@ if __name__ == "__main__":
     #    0   : Serial Mode (traditional gaudirun)
     #    n>0 : parallel with n cpus (n <= sys_cpus)
     parser.add_argument("--ncpus", type=int, default=0,
-                      help="Start Gaudi in parallel mode using NCPUS processes. "
-                           "0 => serial mode (default), -1 => use all CPUs")
+                        help="Start Gaudi in parallel mode using NCPUS processes. "
+                        "0 => serial mode (default), -1 => use all CPUs")
 
     # Once to parse the files and another time to have the new parameters
     # in the namespace since parsing of the file happens when the namespace
     # has already been filled
-    opts = parser.parse_args()
+    opts = parser.parse_known_args()
     opts = parser.parse_args()
 
     # print a doc line showing the configured algorithms
@@ -120,7 +123,7 @@ if __name__ == "__main__":
         cfgDb = Configuration.cfgDb
         logger.info("Available components:\n%s" % (21 * "="))
         for item in sorted(cfgDb):
-            if True: # another option could filter Gaudi components here
+            if True:  # another option could filter Gaudi components here
               try:
                 path_to_component = __import__(cfgDb[item]["module"]).__file__
               except ImportError:


### PR DESCRIPTION
BEGINRELEASENOTES
- Add improvements to k4run: clean up code, use the logging module, parse all the arguments using argparse, sort display of options

ENDRELEASENOTES

- Parsing is done using `argparse` only instead of the previous combination of manual parsing and `argparse`. I think this is cleaner and if the arguments are wrong it will show the usage automatically (before there was a explicit testing of this)
- Code was cleaned up a bit, for example there were very deeply nested if/for that can be changed a bit. Indentation is (and was) inconsistent so if we agree on 2 or 4 spaces I can change that; it makes the diff very hard to read so we can keep it for the last change.
- Previously the display of options wouldn't be sorted and would be different each time because there was a `list(set(` that has undetermined ordering, now it will always be sorted in the same order as they were defined in the file (for python >= 3.7, since it is a one liner in that case).
- Now using `logging` for messages as per #50. Right now there is a `[k4run]` for the messages that come from `k4run` but this is a placeholder. For example for the Gaudi processes the format looks like `[ MESSAGE "VXDEndcapDigitiser"]` and many things can be done like adding the date, the level of the message, etc. I don't have a strong opinion. This is how it looks now:

``` python
[k4run] LcioEvent --> MyAIDAProcessor --> EventNumber --> InitDD4hep --> Config --> OverlayFalse --> VXDBarrelDigitiser --> VXDEndcapDigitiser --> InnerPlanarDigiProcessor --> InnerEndcapPlanarDigiProcessor --> OuterPlanarDigiProcessor --> OuterEndcapPlanarDigiProcessor --> MyConformalTracking --> ClonesAndSplitTracksFinder --> Refit --> MyDDCaloDigi --> MyDDSimpleMuonDigi --> MyDDMarlinPandora --> LumiCalReco --> MergeRP --> MergeClusters --> MyClicEfficiencyCalculator --> MyRecoMCTruthLinker --> MyTrackChecker --> CLICPfoSelectorDefault_HE --> CLICPfoSelectorLoose_HE --> CLICPfoSelectorTight_HE --> CLICPfoSelectorDefault_LE --> CLICPfoSelectorLoose_LE --> CLICPfoSelectorTight_LE --> RenameCollection --> VertexFinder --> JetClusteringAndRefiner --> Output_REC --> Output_DST
[k4run] Option name: EventDataSvc.OutputLevel EventDataSvc.OutputLevel 0
[k4run] Option name: LcioEvent.OutputLevel LcioEvent.OutputLevel 4
[k4run] Option name: LcioEvent.Files LcioEvent.Files ['ttbar.slcio']
[k4run] Option name: InitDD4hep.OutputLevel InitDD4hep.OutputLevel 4
[k4run] Option name: InitDD4hep.ProcessorType InitDD4hep.ProcessorType InitializeDD4hep
```

I ran `clicReconstruction.py` on the same file and got similar results 

Other related issues:
- #89 I could reproduce with the podio reader but this has been fixed in https://github.com/AIDASoft/podio/pull/355. With the LCIO reader it exits without crashing. Can we close it?
- #90 <strike>I checked and certainly by default the option to attach `gdb` is set to false for Gaudi. I could reproduce this issue with the podio reader before https://github.com/AIDASoft/podio/pull/355 (by trying to open a non-existent file, now fixed), where `TFile.Open` fails and pulls `gdb`. It was very very slow. Interestingly I ran with everything local (without `cvmfs`) and it took just a couple of seconds to display the backtrace, so `cvmfs` is at least partly responsible for the slowness.</strike> Already closed.
- #72 Using `--npcus` with a number different from 0 fails with:

``` python
  File "/cvmfs/sw.hsf.org/spackages6/gaudi/36.5/x86_64-centos7-gcc11.2.0-opt/z2prd/python/Gaudi/Main.py", line 476, in run
    result = self.runParallel(ncpus)
  File "/cvmfs/sw.hsf.org/spackages6/gaudi/36.5/x86_64-centos7-gcc11.2.0-opt/z2prd/python/Gaudi/Main.py", line 561, in runParallel
    Parall = gpp.Coord(ncpus, c, self.log)
  File "/cvmfs/sw.hsf.org/spackages6/gaudi/36.5/x86_64-centos7-gcc11.2.0-opt/z2prd/python/GaudiMP/GMPBase.py", line 1378, in __init__
    sub = Subworker(
  File "/cvmfs/sw.hsf.org/spackages6/gaudi/36.5/x86_64-centos7-gcc11.2.0-opt/z2prd/python/GaudiMP/GMPBase.py", line 834, in __init__
    GMPComponent.__init__(
  File "/cvmfs/sw.hsf.org/spackages6/gaudi/36.5/x86_64-centos7-gcc11.2.0-opt/z2prd/python/GaudiMP/GMPBase.py", line 473, in __init__
    self.msgFormat = self.config["MessageSvc"].Format
KeyError: 'MessageSvc'
```