### PR TITLE
Make sure libGaudiCoreSvc.so is found by genconf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ find_package(ROOT COMPONENTS RIO Tree)
 #---------------------------------------------------------------
 # Load macros and functions for Gaudi-based projects
 find_package(Gaudi)
+get_filename_component(Gaudi_CMakeDir ${GAUDI_TOOLBOX_DIR} DIRECTORY)
+get_filename_component(GAUDI_LIB_DIR ${Gaudi_CMakeDir} DIRECTORY)
 #---------------------------------------------------------------
 
 include(GNUInstallDirs)

--- a/k4FWCore/CMakeLists.txt
+++ b/k4FWCore/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(podio)
 
 gaudi_install(SCRIPTS)
 
+file(COPY ${GAUDI_LIB_DIR}/libGaudiCoreSvc.so DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
 gaudi_add_library(k4FWCore
 		  SOURCES src/PodioDataSvc.cpp

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -4,8 +4,7 @@
 
 find_package(EDM4HEP)
 
-
-
+file(COPY ${GAUDI_LIB_DIR}/libGaudiCoreSvc.so DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
 
 file(GLOB k4fwcoretest_plugin_sources src/components/*.cpp)
 gaudi_add_module(k4FWCoreTestPlugins


### PR DESCRIPTION
Fixes several dlopen failures on MacOsX of this sort:

WARNING: cannot load libGaudiCoreSvc.so for factory ApplicationMgr
WARNING: dlopen(libGaudiCoreSvc.so, 0x0009): tried: 'libGaudiCoreSvc.so' (no such file), '/usr/local/lib/libGaudiCoreSvc.so' (no such file), '/usr/lib/libGaudiCoreSvc.so' (no such file), '/Users/ganis/local/key4hep/build/k4FWcore/test/k4FWCoreTest/libGaudiCoreSvc.so' (no such file)

Setting LD_LIBRARY_PATH and similar does not work, but perhaps there is another way to fix it.

BEGINRELEASENOTES
- Fixes several dlopen failures on MacOsX due to libGaudiCoreSvc.so not being found.
ENDRELEASENOTES
