### PR TITLE
Make type names string_view save

### DIFF
--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -104,7 +104,7 @@ void PodioOutput::createBranches(const std::vector<std::pair<std::string, podio:
     const auto collID = m_podioDataSvc->getCollectionIDs()->collectionID(collName);
     // No check necessary, only registered collections possible
     auto       coll     = collNamePair.second;
-    const auto collType = coll->getValueTypeName() + "Collection";
+    const auto collType = std::string(coll->getValueTypeName()) + "Collection";
     collectionInfo->emplace_back(collID, std::move(collType), coll->isSubsetCollection());
     //}
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Make usage of `getXXXTypeName` work with `std::string` and `std::string_view` as podio switches to return `std::string_view` in https://github.com/AIDASoft/podio/pull/402.

ENDRELEASENOTES
