### PR TITLE
Fix compilation with gcc13.

### DIFF
--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -29,7 +29,7 @@ private:
   T* m_data;
 };
 
-template <class T> DataWrapper<T>::~DataWrapper<T>() {
+template <class T> DataWrapper<T>::~DataWrapper() {
   if (m_data != nullptr)
     delete m_data;
 }


### PR DESCRIPTION
Compiling with gcc version 13.1.1 20230519 on Fedora 38, i get an error:

```
In file included from /home/sss/fcc/soft/k4FWCore/k4FWCore/src/PodioDataSvc.cpp:6:
/home/sss/fcc/soft/k4FWCore/k4FWCore/include/k4FWCore/DataWrapper.h:32:36: error: template-id not allowed for destructor
   32 | template <class T> DataWrapper<T>::~DataWrapper<T>() {
      |                                    ^
```

This fixes the error.


BEGINRELEASENOTES
- Fix compilation with gcc13.

ENDRELEASENOTES
