### PR TITLE
Fix DataHandle to work as expected when used with LegacyDataSvc

### DIFF
--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -77,7 +77,9 @@ DataHandle<T>::DataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode
 
     podio_data_service = dynamic_cast<PodioDataSvc*>(m_eds.get());
     if (nullptr != podio_data_service) {
-      m_dataPtr = new T();
+      if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+        m_dataPtr = new T();
+      }
     } else {
       // This is the legacy implementation kept for a transition period
       PodioLegacyDataSvc* plds;

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -193,8 +193,13 @@ template <typename T> T* DataHandle<T>::createAndPut() {
 
 // Temporary workaround for k4MarlinWrapper
 template <typename T> const std::string DataHandle<T>::getCollMetadataCellID(const unsigned int id) {
-  std::cerr << "k4FWCore: getCollMetadataCellID is not implemented!" << std::endl;
-  return "";
+  if (auto lpds = dynamic_cast<PodioLegacyDataSvc*>(m_eds.get())) {
+    auto colMD = lpds->getProvider().getCollectionMetaData(id);
+    return colMD.getValue<std::string>("CellIDEncodingString");
+  }
+
+  throw GaudiException("getCollMetadataCellID is only implemented for the legacy data svc",
+                       "Cannot get collection metadata", StatusCode::FAILURE);
 }
 
 // temporary to allow property declaration


### PR DESCRIPTION
BEGINRELEASENOTES
- Only create an internal data ptr for integral or floating point types. This avoids leaking the pointer otherwise and also makes it possible to create a `DataHandle` with an abstract base type.
- Make the `getCollMetadataCellID` method work as expected when a `DataHandle` is backed by the `PodioLegacyDataSvc`

ENDRELEASENOTES

This partially addresses the CI failures in key4hep/k4MarlinWrapper#114 . Now the only thing that is left is an exception in `prepareForWrite` in podio, potentially related to some conversion issues.

The empty implementation introduced in #115 was not enough.
