### PR TITLE
Fix segfault when trying to read potentially non-existant category

### DIFF
--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -34,7 +34,12 @@ StatusCode PodioDataSvc::initialize() {
   }
 
   if (m_reading_from_file) {
-    m_metadataframe = m_reader.readEntry("metadata", 0);
+    if (auto metadata = m_reader.readEntry("metadata", 0)) {
+      m_metadataframe = std::move(metadata);
+    } else {
+      warning() << "Reading file without a 'metadata' category." << endmsg;
+      m_metadataframe = podio::Frame();
+    }
   } else {
     m_metadataframe = podio::Frame();
   }


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to check whether the `metadata` category is actually present before trying to construct a `Frame` from it.

ENDRELEASENOTES

Will segfault otherwise. Issue reported via email:

> Hi Thomas,
when I try the nightly release I get a similar seg fault.
Cheers,
Carsten
>
> ```
> #6  0x00007f8bdd35239e in podio::Frame::FrameModel<podio::ROOTFrameData>::FrameModel(std::unique_ptr<podio::ROOTFrameData, std::default_delete<podio::ROOTFrameData> >) () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-06-30/x86_64-centos7-gcc12.2.0-opt/k4fwcore/7cb8e8310dd4ca42b6147be8053de8a2589daa11=develop-74nukk/lib/libk4FWCore.so
> #7  0x00007f8bdd3460d7 in PodioDataSvc::initialize() () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-06-30/x86_64-centos7-gcc12.2.0-opt/k4fwcore/7cb8e8310dd4ca42b6147be8053de8a2589daa11=develop-74nukk/lib/libk4FWCore.so
> #8  0x00007f8bf56d956f in Service::sysInitialize_imp() () from /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-06-24/x86_64-centos7-gcc12.2.0-opt/gaudi/36.10-xtb3ml/lib/libGaudiKernel.so
> #9  0x00007f8bf9ca420b in __pthread_once_slow () from /lib64/libpthread.so.0
> ````