### PR TITLE
k4run: add missing import for VERBOSE

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -148,6 +148,7 @@ if __name__ == "__main__":
       propTuple[0].setProp(propTuple[1].rsplit(".",1)[1], opts_dict[optionName])
 
     if opts.verbose:
+      from Gaudi.Configuration import VERBOSE
       ApplicationMgr().OutputLevel = VERBOSE
     if opts.num_events is not None:
       ApplicationMgr().EvtMax = opts.num_events

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -144,3 +144,10 @@ add_test(NAME Testk4runCustomArguments
 set_test_env(Testk4runCustomArguments)
 set_tests_properties(Testk4runCustomArguments
   PROPERTIES PASS_REGULAR_EXPRESSION "The answer is 42")
+
+add_test(NAME Testk4runVerboseOutput
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+         COMMAND ${K4RUN} --verbose options/TestArgs.py)
+set_test_env(Testk4runVerboseOutput)
+set_tests_properties(Testk4runVerboseOutput
+  PROPERTIES PASS_REGULAR_EXPRESSION " VERBOSE ")


### PR DESCRIPTION
BEGINRELEASENOTES
- k4run: fix missing import for VERBOSE

ENDRELEASENOTES
