### PR TITLE
Keep looping through configurables

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -27,7 +27,9 @@ def load_file(file):
 
 
 def add_arguments(parser, app_mgr):
-  for conf in dict.fromkeys(app_mgr.allConfigurables.values()):
+  # length increases when properties of an algorithm with tools are inspected
+  # see https://github.com/key4hep/k4FWCore/pull/138
+  for conf in tuple(app_mgr.allConfigurables.values()):
     # skip public tools and the applicationmgr itself
     if "ToolSvc" in conf.name() or "ApplicationMgr" in conf.name():
       continue

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -27,8 +27,7 @@ def load_file(file):
 
 
 def add_arguments(parser, app_mgr):
-  configurables = app_mgr.allConfigurables.values()
-  for conf in configurables:
+  for conf in dict.fromkeys(app_mgr.allConfigurables.values()):
     # skip public tools and the applicationmgr itself
     if "ToolSvc" in conf.name() or "ApplicationMgr" in conf.name():
       continue


### PR DESCRIPTION
BEGINRELEASENOTES

- Keep looping through configurables with `dict.fromkeys()`

ENDRELEASENOTES

Otherwise, I'm getting the following error with [this](https://github.com/HEP-FCC/k4RecCalorimeter/blob/main/RecFCCeeCalorimeter/tests/options/runCaloSim.py) configuration file.
```
Traceback (most recent call last):                                                                         
  File "/home/jsmiesko/Work/FCC/k4FWCore/install/bin/k4run", line 140, in <module>                         
    add_arguments(parser, ApplicationMgr())                                                                
  File "/home/jsmiesko/Work/FCC/k4FWCore/install/bin/k4run", line 32, in add_arguments                     
    for conf in configurables:                                                                             
RuntimeError: dictionary changed size during iteration
```

Nota bene: The configuration file has also other problems  :)