### PR TITLE
IGeoSvc: add constantAsString accessor

### DIFF
--- a/k4Interface/include/k4Interface/IGeoSvc.h
+++ b/k4Interface/include/k4Interface/IGeoSvc.h
@@ -32,10 +32,11 @@ class G4VUserDetectorConstruction;
 class GAUDI_API IGeoSvc : virtual public IService {
 public:
   DeclareInterfaceID(IGeoSvc, 1, 0);
-  virtual dd4hep::DetElement           getDD4HepGeo()                            = 0;
-  virtual dd4hep::Detector*            lcdd()                                    = 0;
-  virtual G4VUserDetectorConstruction* getGeant4Geo()                            = 0;
-  virtual std::string                  constantAsString(std::string const& name) = 0;
+  virtual dd4hep::DetElement                                            getDD4HepGeo()                            = 0;
+  [[deprecated("Use getDetector() instead")]] virtual dd4hep::Detector* lcdd()                                    = 0;
+  virtual dd4hep::Detector*                                             getDetector()                             = 0;
+  virtual G4VUserDetectorConstruction*                                  getGeant4Geo()                            = 0;
+  virtual std::string                                                   constantAsString(std::string const& name) = 0;
   virtual ~IGeoSvc() {}
 };
 

--- a/k4Interface/include/k4Interface/IGeoSvc.h
+++ b/k4Interface/include/k4Interface/IGeoSvc.h
@@ -32,9 +32,10 @@ class G4VUserDetectorConstruction;
 class GAUDI_API IGeoSvc : virtual public IService {
 public:
   DeclareInterfaceID(IGeoSvc, 1, 0);
-  virtual dd4hep::DetElement           getDD4HepGeo() = 0;
-  virtual dd4hep::Detector*            lcdd()         = 0;
-  virtual G4VUserDetectorConstruction* getGeant4Geo() = 0;
+  virtual dd4hep::DetElement           getDD4HepGeo()                            = 0;
+  virtual dd4hep::Detector*            lcdd()                                    = 0;
+  virtual G4VUserDetectorConstruction* getGeant4Geo()                            = 0;
+  virtual std::string                  constantAsString(std::string const& name) = 0;
   virtual ~IGeoSvc() {}
 };
 


### PR DESCRIPTION
This lets us isolate other components from a direct DD4hep dependency


BEGINRELEASENOTES
- IGeoSvc: Add function constantAsString, to access dd4hep constants, but isolating other components from DD4hep
- IGeoSvc: Add function getDetector as a replacement for the new deprecated lcdd function

ENDRELEASENOTES


This is part of addressing: key4hep/k4MarlinWrapper#27