### PR TITLE
Fix clang warnings by adding final

### DIFF
--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -45,12 +45,12 @@ class PodioDataSvc : public DataSvc {
 public:
   typedef std::vector<std::pair<std::string, podio::CollectionBase*>> CollRegistry;
 
-  virtual StatusCode initialize();
-  virtual StatusCode reinitialize();
-  virtual StatusCode finalize();
-  virtual StatusCode clearStore();
-  virtual StatusCode i_setRoot(std::string root_path, IOpaqueAddress* pRootAddr);
-  virtual StatusCode i_setRoot(std::string root_path, DataObject* pRootObj);
+  StatusCode initialize() final;
+  StatusCode reinitialize() final;
+  StatusCode finalize() final;
+  StatusCode clearStore() final;
+  StatusCode i_setRoot(std::string root_path, IOpaqueAddress* pRootAddr) final;
+  StatusCode i_setRoot(std::string root_path, DataObject* pRootObj) final;
 
   /// Standard Constructor
   PodioDataSvc(const std::string& name, ISvcLocator* svc);

--- a/k4FWCore/include/k4FWCore/PodioLegacyDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioLegacyDataSvc.h
@@ -40,10 +40,10 @@ class PodioLegacyDataSvc : public DataSvc {
 public:
   typedef std::vector<std::pair<std::string, podio::CollectionBase*>> CollRegistry;
 
-  virtual StatusCode initialize();
-  virtual StatusCode reinitialize();
-  virtual StatusCode finalize();
-  virtual StatusCode clearStore();
+  StatusCode initialize() final;
+  StatusCode reinitialize() final;
+  StatusCode finalize() final;
+  StatusCode clearStore() final;
 
   /// Standard Constructor
   PodioLegacyDataSvc(const std::string& name, ISvcLocator* svc);


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix clang warning inconsistent-missing-override by adding final

ENDRELEASENOTES

Supersedes https://github.com/key4hep/k4FWCore/pull/96 (fixes a few more warnings)
