### PR TITLE
Remove init.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,5 @@ repos:
         "-n", "Key4hep",
         "-u", "https://key4hep.github.io/key4hep-doc/",
         "-x", ".github/*", ".pre-commit-config.yaml", "README.md",
-              "doc/ReleaseNotes.md", ".k4fwcore-ci.d/*", "init.sh",
+              "doc/ReleaseNotes.md", ".k4fwcore-ci.d/*",
         "-f"]

--- a/init.sh
+++ b/init.sh
@@ -1,3 +1,0 @@
-
-source  /cvmfs/sw.hsf.org/key4hep/setup.sh
-


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove init.sh, a script that sources the key4hep stack

ENDRELEASENOTES

I don't think anyone uses this and it isn't particularly useful