### PR TITLE
Add edm4hep::EventHeaderCollection to the list of clasess that can be used with Gaudi::Functional

### DIFF
--- a/k4FWCore/components/PodioInput.cpp
+++ b/k4FWCore/components/PodioInput.cpp
@@ -21,6 +21,7 @@
 
 #include "k4FWCore/PodioDataSvc.h"
 
+#include "edm4hep/EventHeaderCollection.h"
 #include "edm4hep/CaloHitContributionCollection.h"
 #include "edm4hep/CalorimeterHitCollection.h"
 #include "edm4hep/ClusterCollection.h"
@@ -169,6 +170,9 @@ void PodioInput::fillReaders() {
   };
   m_readers["podio::UserDataCollection<uint64_t>"] = [&](std::string_view collName) {
     maybeRead<podio::UserDataCollection<uint64_t>>(collName);
+  };
+  m_readers["edm4hep::EventHeaderCollection"] = [&](std::string_view collName) {
+    maybeRead<edm4hep::EventHeaderCollection>(collName);
   };
 }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Add edm4hep::EventHeaderCollection to the list of clasess that can be used with Gaudi::Functional 

ENDRELEASENOTES