### PR TITLE
Fix issue with narrowing

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducer.cpp
@@ -34,8 +34,8 @@ struct ExampleFunctionalProducer final : Gaudi::Functional::Producer<edm4hep::MC
   // This is the function that will be called to produce the data
   edm4hep::MCParticleCollection operator()() const override {
     auto coll = edm4hep::MCParticleCollection();
-    coll.create(1, 2, 3, 4, 5, 6);
-    coll.create(2, 3, 4, 5, 6, 7);
+    coll.create(1, 2, 3, static_cast<float>(4.), static_cast<float>(5.), static_cast<float>(6.));
+    coll.create(2, 3, 4, static_cast<float>(5.), static_cast<float>(6.), static_cast<float>(7.));
     // We have to return whatever collection type we specified in the
     // template argument
     return coll;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix issue with narrowing when compiling with clang; cast numbers to `float` which is the right type in EDM4hep instead of letting them being `int` or `double`

ENDRELEASENOTES

Needed after https://github.com/key4hep/k4FWCore/pull/165, maybe it will be fine when types are changed to double in EDM4hep.

Error message (when trying with doubles, originally it was int):

``` c++
/EDM4hep/edm4hep/edm4hep/MCParticleCollection.h:242:57: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
  auto obj = new MCParticleObj({size, m_collectionID}, {std::forward<Args>(args)...});
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
/k4FWCore/test/k4FWCoreTest/src/components/ExampleFunctionalProducer.cpp:37:10: note: in instantiation of function template specialization 'edm4hep::MCParticleCollection::create<int, int, int, double, double, double>' requested here
    coll.create(1, 2, 3, 4., 5., 6.);
         ^
/EDM4hep/edm4hep/edm4hep/MCParticleCollection.h:242:57: note: insert an explicit cast to silence this issue
  auto obj = new MCParticleObj({size, m_collectionID}, {std::forward<Args>(args)...});
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~
                                                        static_cast<float>(     ) 

```