### PR TITLE
Make it possible to transparently migrate to TrackerHit interface

### DIFF
--- a/k4FWCore/components/PodioInput.cpp
+++ b/k4FWCore/components/PodioInput.cpp
@@ -95,6 +95,11 @@ void PodioInput::fillReaders() {
   m_readers["edm4hep::TrackerHit3DCollection"] = [&](std::string_view collName) {
     maybeRead<edm4hep::TrackerHit3DCollection>(collName);
   };
+  m_readers["edm4hep::TrackerHitCollection"] = [&](std::string_view collName) {
+    warning() << "Reading a TrackerHitCollection via TrackerHit3DCollection (" << collName
+              << "). Make sure to transition properly" << endmsg;
+    maybeRead<edm4hep::TrackerHit3DCollection>(collName);
+  };
   m_readers["edm4hep::TrackerHitPlaneCollection"] = [&](std::string_view collName) {
     maybeRead<edm4hep::TrackerHitPlaneCollection>(collName);
   };

--- a/k4FWCore/components/PodioInput.cpp
+++ b/k4FWCore/components/PodioInput.cpp
@@ -45,7 +45,14 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/TrackerPulseCollection.h"
 #include "edm4hep/VertexCollection.h"

--- a/k4FWCore/components/PodioInput.cpp
+++ b/k4FWCore/components/PodioInput.cpp
@@ -45,7 +45,7 @@
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TimeSeriesCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "edm4hep/TrackerHitPlaneCollection.h"
 #include "edm4hep/TrackerPulseCollection.h"
 #include "edm4hep/VertexCollection.h"
@@ -85,8 +85,8 @@ void PodioInput::fillReaders() {
   m_readers["edm4hep::ClusterCollection"] = [&](std::string_view collName) {
     maybeRead<edm4hep::ClusterCollection>(collName);
   };
-  m_readers["edm4hep::TrackerHitCollection"] = [&](std::string_view collName) {
-    maybeRead<edm4hep::TrackerHitCollection>(collName);
+  m_readers["edm4hep::TrackerHit3DCollection"] = [&](std::string_view collName) {
+    maybeRead<edm4hep::TrackerHit3DCollection>(collName);
   };
   m_readers["edm4hep::TrackerHitPlaneCollection"] = [&](std::string_view collName) {
     maybeRead<edm4hep::TrackerHitPlaneCollection>(collName);

--- a/k4FWCore/components/PodioInput.cpp
+++ b/k4FWCore/components/PodioInput.cpp
@@ -96,8 +96,6 @@ void PodioInput::fillReaders() {
     maybeRead<edm4hep::TrackerHit3DCollection>(collName);
   };
   m_readers["edm4hep::TrackerHitCollection"] = [&](std::string_view collName) {
-    warning() << "Reading a TrackerHitCollection via TrackerHit3DCollection (" << collName
-              << "). Make sure to transition properly" << endmsg;
     maybeRead<edm4hep::TrackerHit3DCollection>(collName);
   };
   m_readers["edm4hep::TrackerHitPlaneCollection"] = [&](std::string_view collName) {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -31,7 +31,6 @@ namespace edm4hep {
   using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 }  // namespace edm4hep
 #endif
-#include "edm4hep/TrackerHitPlaneCollection.h"
 #include "podio/UserDataCollection.h"
 
 // Define BaseClass_t

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -23,7 +23,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "podio/UserDataCollection.h"
 
 // Define BaseClass_t
@@ -37,7 +37,7 @@
 using FloatColl         = podio::UserDataCollection<float>;
 using ParticleColl      = edm4hep::MCParticleCollection;
 using SimTrackerHitColl = edm4hep::SimTrackerHitCollection;
-using TrackerHitColl    = edm4hep::TrackerHitCollection;
+using TrackerHitColl    = edm4hep::TrackerHit3DCollection;
 using TrackColl         = edm4hep::TrackCollection;
 
 struct ExampleFunctionalConsumerMultiple final

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -23,7 +23,15 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
+#include "edm4hep/TrackerHitPlaneCollection.h"
 #include "podio/UserDataCollection.h"
 
 // Define BaseClass_t

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -32,7 +32,6 @@ namespace edm4hep {
   using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 }  // namespace edm4hep
 #endif
-#include "edm4hep/TrackerHitPlaneCollection.h"
 #include "podio/UserDataCollection.h"
 
 #include <string>

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -24,7 +24,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "podio/UserDataCollection.h"
 
 #include <string>
@@ -33,7 +33,7 @@
 using Float         = podio::UserDataCollection<float>;
 using Particle      = edm4hep::MCParticleCollection;
 using SimTrackerHit = edm4hep::SimTrackerHitCollection;
-using TrackerHit    = edm4hep::TrackerHitCollection;
+using TrackerHit    = edm4hep::TrackerHit3DCollection;
 using Track         = edm4hep::TrackCollection;
 
 struct ExampleFunctionalProducerMultiple final
@@ -71,7 +71,7 @@ struct ExampleFunctionalProducerMultiple final
     auto hit            = simTrackerHits.create();
     hit.setPosition({3, 4, 5});
 
-    auto trackerHits = edm4hep::TrackerHitCollection();
+    auto trackerHits = edm4hep::TrackerHit3DCollection();
     auto trackerHit  = trackerHits.create();
     trackerHit.setPosition({3, 4, 5});
 

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -24,7 +24,15 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
+#include "edm4hep/TrackerHitPlaneCollection.h"
 #include "podio/UserDataCollection.h"
 
 #include <string>

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
@@ -23,7 +23,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #include "podio/UserDataCollection.h"
 
 // Define BaseClass_t
@@ -35,7 +35,7 @@
 using FloatColl         = podio::UserDataCollection<float>;
 using ParticleColl      = edm4hep::MCParticleCollection;
 using SimTrackerHitColl = edm4hep::SimTrackerHitCollection;
-using TrackerHitColl    = edm4hep::TrackerHitCollection;
+using TrackerHitColl    = edm4hep::TrackerHit3DCollection;
 using TrackColl         = edm4hep::TrackCollection;
 
 // As a simple example, we'll write an integer and a collection of MCParticles

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
@@ -23,6 +23,14 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
 #include "edm4hep/TrackerHit3DCollection.h"
 #include "podio/UserDataCollection.h"
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
@@ -23,7 +23,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 
 DECLARE_COMPONENT(k4FWCoreTest_CheckExampleEventData)
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
@@ -23,7 +23,15 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
 #include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
+#include "edm4hep/TrackerHitPlaneCollection.h"
 
 DECLARE_COMPONENT(k4FWCoreTest_CheckExampleEventData)
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -29,10 +29,6 @@
 // datamodel
 namespace edm4hep {
   class MCParticleCollection;
-  class SimTrackerHitCollection;
-  class TrackerHitCollection;
-  class SimCaloHitCollection;
-  class TrackCollection;
 }  // namespace edm4hep
 
 class k4FWCoreTest_CheckExampleEventData : public GaudiAlgorithm {

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -24,7 +24,7 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHitCollection.h"
+#include "edm4hep/TrackerHit3DCollection.h"
 #if __has_include("edm4hep/EDM4hepVersion.h")
 #include "edm4hep/EDM4hepVersion.h"
 #else
@@ -74,8 +74,8 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute() {
   auto                              hit            = simTrackerHits->create();
   hit.setPosition({3, 4, 5});
 
-  edm4hep::TrackerHitCollection* trackerHits = m_TrackerHitHandle.createAndPut();
-  auto                           trackerHit  = trackerHits->create();
+  edm4hep::TrackerHit3DCollection* trackerHits = m_TrackerHitHandle.createAndPut();
+  auto                             trackerHit  = trackerHits->create();
   trackerHit.setPosition({3, 4, 5});
 
   edm4hep::TrackCollection* tracks = m_trackHandle.createAndPut();

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -24,7 +24,6 @@
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
-#include "edm4hep/TrackerHit3DCollection.h"
 #if __has_include("edm4hep/EDM4hepVersion.h")
 #include "edm4hep/EDM4hepVersion.h"
 #else

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -32,7 +32,7 @@
 namespace edm4hep {
   class MCParticleCollection;
   class SimTrackerHitCollection;
-  class TrackerHitCollection;
+  class TrackerHit3DCollection;
   class SimCaloHitCollection;
   class TrackCollection;
 }  // namespace edm4hep
@@ -69,7 +69,7 @@ private:
   DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Writer, this};
   /// Handle for the SimTrackerHits to be written
   DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHits", Gaudi::DataHandle::Writer, this};
-  DataHandle<edm4hep::TrackerHitCollection>    m_TrackerHitHandle{"TrackerHits", Gaudi::DataHandle::Writer, this};
+  DataHandle<edm4hep::TrackerHit3DCollection>  m_TrackerHitHandle{"TrackerHits", Gaudi::DataHandle::Writer, this};
 
   /// Handle for the Tracks to be written
   DataHandle<edm4hep::TrackCollection> m_trackHandle{"Tracks", Gaudi::DataHandle::Writer, this};

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -25,6 +25,17 @@
 // key4hep
 #include "k4FWCore/DataHandle.h"
 
+// edm4hep
+#if __has_include("edm4hep/TrackerHit3DCollection.h")
+#include "edm4hep/TrackerHit3DCollection.h"
+#else
+#include "edm4hep/TrackerHitCollection.h"
+namespace edm4hep {
+  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
+}  // namespace edm4hep
+#endif
+#include "edm4hep/TrackerHitPlaneCollection.h"
+
 // podio
 #include "podio/UserDataCollection.h"
 
@@ -32,7 +43,6 @@
 namespace edm4hep {
   class MCParticleCollection;
   class SimTrackerHitCollection;
-  class TrackerHit3DCollection;
   class SimCaloHitCollection;
   class TrackCollection;
 }  // namespace edm4hep

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -34,7 +34,6 @@ namespace edm4hep {
   using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
 }  // namespace edm4hep
 #endif
-#include "edm4hep/TrackerHitPlaneCollection.h"
 
 // podio
 #include "podio/UserDataCollection.h"


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix usages of `edm4hep::TrackerHit` to `edm4hep::TrackerHit3D` in order to keep things working after key4hep/EDM4hep#252
  - Check for the existance of the `TrackerHit3D` and tpyedef the `TrackerHit` to `TrackerHit3D` if it does not exist

ENDRELEASENOTES


- [x] Preprocessor ifs to have this working with older versions of EDM4hep for some time?
- [x] AIDASoft/podio#516
~- [x] key4hep/EDM4hep#252~