### PR TITLE
Remove the deprecated lcdd() from GeoSvc Interface

### DIFF
--- a/k4Interface/include/k4Interface/IGeoSvc.h
+++ b/k4Interface/include/k4Interface/IGeoSvc.h
@@ -32,10 +32,10 @@ class G4VUserDetectorConstruction;
 class GAUDI_API IGeoSvc : virtual public IService {
 public:
   DeclareInterfaceID(IGeoSvc, 1, 0);
-  virtual dd4hep::DetElement                                            getDD4HepGeo()                            = 0;
-  virtual dd4hep::Detector*                                             getDetector()                             = 0;
-  virtual G4VUserDetectorConstruction*                                  getGeant4Geo()                            = 0;
-  virtual std::string                                                   constantAsString(std::string const& name) = 0;
+  virtual dd4hep::DetElement           getDD4HepGeo()                            = 0;
+  virtual dd4hep::Detector*            getDetector()                             = 0;
+  virtual G4VUserDetectorConstruction* getGeant4Geo()                            = 0;
+  virtual std::string                  constantAsString(std::string const& name) = 0;
   virtual ~IGeoSvc() {}
 };
 

--- a/k4Interface/include/k4Interface/IGeoSvc.h
+++ b/k4Interface/include/k4Interface/IGeoSvc.h
@@ -33,7 +33,6 @@ class GAUDI_API IGeoSvc : virtual public IService {
 public:
   DeclareInterfaceID(IGeoSvc, 1, 0);
   virtual dd4hep::DetElement                                            getDD4HepGeo()                            = 0;
-  [[deprecated("Use getDetector() instead")]] virtual dd4hep::Detector* lcdd()                                    = 0;
   virtual dd4hep::Detector*                                             getDetector()                             = 0;
   virtual G4VUserDetectorConstruction*                                  getGeant4Geo()                            = 0;
   virtual std::string                                                   constantAsString(std::string const& name) = 0;


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated lcdd() from GeoSvc Interface

ENDRELEASENOTES
