### PR TITLE
Clean up the build workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,6 @@ jobs:
       matrix:
         cvmfs_base: ['sft.cern.ch/lcg/views']
         ENVIRONMENT: ['dev3/latest/x86_64-centos7-gcc11-opt']
-        include:
-        - cvmfs_base: 'sw.hsf.org'
-          ENVIRONMENT: 'key4hep'
-        - cvmfs_base: 'sw-nightlies.hsf.org'
-          ENVIRONMENT: 'key4hep'
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the builds for the release and nightlies from the "old" workflow since we already have a workflow that builds for all the supported OSes 

ENDRELEASENOTES

Builds with the LCG stack will fail until https://github.com/key4hep/k4FWCore/pull/172 is merged