### PR TITLE
Fix deprecation warnings for changed mutable accessors

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -68,7 +68,7 @@ struct ExampleFunctionalProducerMultiple final
 
     auto  particles = edm4hep::MCParticleCollection();
     auto  particle  = particles.create();
-    auto& p4        = particle.momentum();
+    auto& p4        = particle.getMomentum();
     p4.x            = m_magicNumberOffset + m_event + 5;
     p4.y            = m_magicNumberOffset + 6;
     p4.z            = m_magicNumberOffset + 7;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
@@ -56,7 +56,7 @@ StatusCode k4FWCoreTest_AlgorithmWithTFile::execute() {
 
   auto particle = particles->create();
 
-  auto& p4 = particle.momentum();
+  auto& p4 = particle.getMomentum();
   p4.x     = m_magicNumberOffset + 5;
   p4.y     = m_magicNumberOffset + 6;
   p4.z     = m_magicNumberOffset + 7;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -63,7 +63,7 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute() {
 
   auto particle = particles->create();
 
-  auto& p4 = particle.momentum();
+  auto& p4 = particle.getMomentum();
   p4.x     = m_magicNumberOffset + m_event + 5;
   p4.y     = m_magicNumberOffset + 6;
   p4.z     = m_magicNumberOffset + 7;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix deprecation warnings for getting mutable references, introduce in AIDASoft/podio#553

ENDRELEASENOTES
