### PR TITLE
Use setMomentum for particles

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -68,10 +68,7 @@ struct ExampleFunctionalProducerMultiple final
 
     auto  particles = edm4hep::MCParticleCollection();
     auto  particle  = particles.create();
-    auto& p4        = particle.getMomentum();
-    p4.x            = m_magicNumberOffset + m_event + 5;
-    p4.y            = m_magicNumberOffset + 6;
-    p4.z            = m_magicNumberOffset + 7;
+    particle.setMomentum({m_magicNumberOffset + m_event + 5.0, m_magicNumberOffset + 6.0, m_magicNumberOffset + 7.0});
     particle.setMass(m_magicNumberOffset + m_event + 8);
 
     auto simTrackerHits = edm4hep::SimTrackerHitCollection();

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -66,8 +66,8 @@ struct ExampleFunctionalProducerMultiple final
     floatVector.push_back(25.);
     floatVector.push_back(m_event);
 
-    auto  particles = edm4hep::MCParticleCollection();
-    auto  particle  = particles.create();
+    auto particles = edm4hep::MCParticleCollection();
+    auto particle  = particles.create();
     particle.setMomentum({m_magicNumberOffset + m_event + 5.0, m_magicNumberOffset + 6.0, m_magicNumberOffset + 7.0});
     particle.setMass(m_magicNumberOffset + m_event + 8);
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
@@ -57,11 +57,7 @@ StatusCode k4FWCoreTest_AlgorithmWithTFile::execute(const EventContext&) const {
   edm4hep::MCParticleCollection* particles = m_mcParticleHandle.createAndPut();
 
   auto particle = particles->create();
-
-  auto& p4 = particle.getMomentum();
-  p4.x     = m_magicNumberOffset + 5;
-  p4.y     = m_magicNumberOffset + 6;
-  p4.z     = m_magicNumberOffset + 7;
+  particle.setMomentum({m_magicNumberOffset + 5.0, m_magicNumberOffset + 6.0, m_magicNumberOffset + 7.0});
   particle.setMass(m_magicNumberOffset + 8);
 
   auto* hits = m_simTrackerHitHandle.createAndPut();

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -64,11 +64,7 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute(const EventContext&) con
   edm4hep::MCParticleCollection* particles = m_mcParticleHandle.createAndPut();
 
   auto particle = particles->create();
-
-  auto& p4 = particle.getMomentum();
-  p4.x     = m_magicNumberOffset + m_event + 5;
-  p4.y     = m_magicNumberOffset + 6;
-  p4.z     = m_magicNumberOffset + 7;
+  particle.setMomentum({m_magicNumberOffset + m_event + 5.0, m_magicNumberOffset + 6.0, m_magicNumberOffset + 7.0});
   particle.setMass(m_magicNumberOffset + m_event + 8);
 
   edm4hep::SimTrackerHitCollection* simTrackerHits = m_simTrackerHitHandle.createAndPut();


### PR DESCRIPTION
BEGINRELEASENOTES
- Use setMomentum for particles, fixing an issue when trying to change a const reference

ENDRELEASENOTES

I'm not sure what has changed since I think that has been there for a time but
the reference from `getMomentum` should be const. Locally I don't need this fix
with clang 17 and I can't reproduce the error when building on top of the latest
nightlies (that are picking up EDM4hep from a few days ago) but on spack I can
reproduce consistently