### PR TITLE
Handle SIGPIPE cleanly

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -116,10 +116,9 @@ def add_arguments(parser, app_mgr):
 class LoggingHandler(logging.StreamHandler):
     def handleError(self, record):
         # Re-raise SIGPIPE generated exception
-        excp = sys.exc_info()[1]  # from Python 3.11 can be replaced with
-                                  # sys.exception()
+        excp = sys.exc_info()[1]  # from Python 3.11 can be replaced with sys.exception()
         if isinstance(excp, BrokenPipeError):
-            raise(excp)
+            raise excp
 
         super().handleError(record)
 
@@ -132,7 +131,7 @@ def main():
     logger.setLevel(logging.INFO)
     # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
     formatter = logging.Formatter("[k4run] %(message)s")
-    handler = LoggingHandler(stream=sys.stdout)
+    handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -113,7 +113,18 @@ def add_arguments(parser, app_mgr):
             )
 
 
-if __name__ == "__main__":
+class LoggingHandler(logging.StreamHandler):
+    def handleError(self, record):
+        # Re-raise SIGPIPE generated exception
+        excp = sys.exc_info()[1]  # from Python 3.11 can be replaced with
+                                  # sys.exception()
+        if isinstance(excp, BrokenPipeError):
+            raise(excp)
+
+        super().handleError(record)
+
+
+def main():
     # ensure that we (and the subprocesses) use the C standard localization
     os.environ["LC_ALL"] = "C"
 
@@ -121,7 +132,7 @@ if __name__ == "__main__":
     logger.setLevel(logging.INFO)
     # formatter = logging.Formatter('[%(asctime)s %(levelname)s] %(message)s', datefmt='%Y-%b-%d %H:%M:%S')
     formatter = logging.Formatter("[k4run] %(message)s")
-    handler = logging.StreamHandler(stream=sys.stdout)
+    handler = LoggingHandler(stream=sys.stdout)
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 
@@ -251,3 +262,14 @@ if __name__ == "__main__":
         if ApplicationMgr().EvtMax == -1 and retcode == 4:
             retcode = 0
         sys.exit(retcode)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BrokenPipeError:
+        # Handle SIGPIPE generated exception
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        os.dup2(devnull, sys.stderr.fileno())
+        sys.exit(1)


### PR DESCRIPTION
BEGINRELEASENOTES
- Handle SIGPIPE signal

ENDRELEASENOTES

Cleanly terminates k4run when one uses it with `head`. Example:
```
k4run --dry-run pythia.py | head -n 1
[k4run] --> Pythia8 --> HepMCToEDMConverter --> StableParticles --> out
```
[more details about Python and SIGPIPE](https://docs.python.org/3/library/signal.html#note-on-sigpipe)

Triggered by https://github.com/HEP-FCC/fcc-tutorials/pull/140