### PR TITLE
Delete the object wrapped by a DataWrapper when the DataWrapper is  destructed

### DIFF
--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -69,7 +69,7 @@ private:
 };
 
 template <class T> DataWrapper<T>::~DataWrapper() {
-  if (is_owner && m_data) {
+  if (is_owner) {
     delete m_data;
   }
 }

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -69,8 +69,9 @@ private:
 };
 
 template <class T> DataWrapper<T>::~DataWrapper() {
-  if (is_owner && !m_data)
+  if (is_owner && m_data) {
     delete m_data;
+  }
 }
 
 template <class T> podio::CollectionBase* DataWrapper<T>::collectionBase() {


### PR DESCRIPTION
BEGINRELEASENOTES
- Delete the object wrapped by a DataWrapper when the DataWrapper is  destructed

ENDRELEASENOTES

Currenty DataWrapper deletes `nullptr`:
```
EventDataSvc         INFO Clearing Podio DataWrappers...
EventDataSvc         INFO Podio DataWrappers cleared. 
EventDataSvc         INFO Clearing the Store...                                                            
DataWrapper: Deleting N6HepMC312GenEventDataE?
DataWrapper: is_owner: 1  
DataWrapper: m_data: 0xbaf5870
DataWrapper: No                                                                                            
DataWrapper: Deleting N7edm4hep20MCParticleCollectionE?
DataWrapper: is_owner: 1                                                                                   
DataWrapper: m_data: 0                               
DataWrapper: Yes
```

