### PR TITLE
Set only one handler for logging in k4run

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -131,7 +131,7 @@ def main():
     formatter = logging.Formatter("[k4run] %(message)s")
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    logger.handlers = [handler]
 
     from k4FWCore.parseArgs import parser
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Set only one handler for logging in k4run, preventing duplication of logging messages

ENDRELEASENOTES

I'm not sure how since I can't reproduce on main (well I only tried one or two steering files), but on https://github.com/key4hep/k4FWCore/pull/173 when running with k4run, sometimes the logging messages will be duplicated:

```
$ k4run ExampleFunctionalMemory.py

[k4run]
# Option name: Transformer.OutputLevel Transformer.OutputLevel 0
[k4run] Option name: Transformer.OutputLevel Transformer.OutputLevel 0
# Option name: Transformer.InputCollection Transformer.InputCollection ['MCParticles']
[k4run] Option name: Transformer.InputCollection Transformer.InputCollection ['MCParticles']
# Option name: Transformer.OutputCollection Transformer.OutputCollection ['NewMCParticles']
[k4run] Option name: Transformer.OutputCollection Transformer.OutputCollection ['NewMCParticles']
# Option name: Transformer.Offset Transformer.Offset 10
[k4run] Option name: Transformer.Offset Transformer.Offset 10
ApplicationMgr    SUCCESS
```

and this seems to be because there is the default handler and the new one that adds the `[k4run]` added. This PR sets the list to only be the one that adds `[k4run]`. 

One could think this is because of https://github.com/key4hep/k4FWCore/pull/173 but `k4run` there is the same as in `main` so nothing should change with respect to logging. Related: https://stackoverflow.com/questions/6729268/log-messages-appearing-twice-with-python-logging