### PR TITLE
Make the Lcio2EDM4hepTool a friend of PodioDataSvc 

### DIFF
--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -50,6 +50,7 @@ template <typename T> class MetaDataHandle;
 class PodioDataSvc : public DataSvc {
   template <typename T> friend class MetaDataHandle;
   friend class PodioOutput;
+  friend class Lcio2EDM4hepTool;
 
 public:
   typedef std::vector<std::pair<std::string, podio::CollectionBase*>> CollRegistry;


### PR DESCRIPTION
BEGINRELEASENOTES
- Make the Lcio2EDM4hepTool a friend of PodioDataSvc to enable event parameter conversion

ENDRELEASENOTES

See discussion in: https://github.com/key4hep/k4MarlinWrapper/pull/184
