### PR TITLE
Make MetaDataHandle::get throw in case the value is not available and add more overloads

### DIFF
--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -28,12 +28,22 @@ public:
   MetaDataHandle(const Gaudi::DataHandle& handle, const std::string& descriptor, Gaudi::DataHandle::Mode a);
   ~MetaDataHandle();
 
+  /// Get the (optional) value that is stored in this MetaDataHandle
+  ///
+  /// @returns A std::optional that is engaged if the value was available as
+  ///          metadata
   const auto get() const;
-  void       put(T);
+
+  /// Set the value for this MetaDataHandle
+  ///
+  /// @note This can only be called during initalize and/or finalize but not
+  /// during execute for algorithms that use it
+  void put(T);
 
 private:
   std::string fullDescriptor() const;
-  void        checkPodioDataSvc();
+
+  void checkPodioDataSvc();
 
 private:
   ServiceHandle<IDataProviderSvc> m_eds;

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -30,8 +30,14 @@ public:
 
   /// Get the (optional) value that is stored in this MetaDataHandle
   ///
-  /// @returns A std::optional that is engaged if the value was available as
-  ///          metadata
+  /// @note The return type of this changes depending on the podio version that
+  /// has been used to build k4FWCore. For pre 1.0 versions of podio this will
+  /// return a default initialized (empty) value in case the underlying
+  /// parameter could not obtained be. For later podio versions this will return
+  /// a std::optional.
+  ///
+  /// @returns Either the (potentially default initialized) value or a
+  /// std::optional that is engaged in case the value is available as metadata
   const auto get() const;
 
   /// Set the value for this MetaDataHandle

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -19,15 +19,7 @@
 #ifndef K4FWCORE_METADATAHANDLE_H
 #define K4FWCORE_METADATAHANDLE_H
 
-// GAUDI
-#include "Gaudi/Algorithm.h"
-
 #include "k4FWCore/PodioDataSvc.h"
-#include "podio/GenericParameters.h"
-
-#include "GaudiKernel/MsgStream.h"
-
-#include <type_traits>
 
 template <typename T> class MetaDataHandle {
 public:

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -28,8 +28,8 @@ public:
   MetaDataHandle(const Gaudi::DataHandle& handle, const std::string& descriptor, Gaudi::DataHandle::Mode a);
   ~MetaDataHandle();
 
-  const T get() const;
-  void    put(T);
+  const auto get() const;
+  void       put(T);
 
 private:
   std::string fullDescriptor() const;
@@ -65,7 +65,7 @@ MetaDataHandle<T>::MetaDataHandle(const Gaudi::DataHandle& handle, const std::st
 }
 
 //---------------------------------------------------------------------------
-template <typename T> const T MetaDataHandle<T>::get() const {
+template <typename T> const auto MetaDataHandle<T>::get() const {
   const auto& frame = m_podio_data_service->getMetaDataFrame();
   return frame.getParameter<T>(fullDescriptor());
 }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -19,6 +19,8 @@
 #include "k4FWCoreTest_cellID_reader.h"
 #include "k4FWCoreTest_cellID_writer.h"
 
+#include "podio/podioVersion.h"
+
 DECLARE_COMPONENT(k4FWCoreTest_cellID_reader)
 
 k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName, ISvcLocator* aSvcLoc)
@@ -41,8 +43,11 @@ StatusCode k4FWCoreTest_cellID_reader::initialize() {
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
-  auto       collID    = simtrackerhits_coll->getID();
+#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
+  const auto cellIDstr = m_cellIDHandle.get().value_or("");
+#else
   const auto cellIDstr = m_cellIDHandle.get();
+#endif
   if (cellIDstr != cellIDtest) {
     error() << "ERROR cellID is: " << cellIDstr << endmsg;
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -43,7 +43,7 @@ StatusCode k4FWCoreTest_cellID_reader::initialize() {
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
-  const auto cellIDstr = m_cellIDHandle.get("");
+  const auto cellIDstr = m_cellIDHandle.get();
 
   if (cellIDstr != cellIDtest) {
     error() << "ERROR cellID is: " << cellIDstr << "expected (" << cellIDtest << ")" << endmsg;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -43,13 +43,10 @@ StatusCode k4FWCoreTest_cellID_reader::initialize() {
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
-#if PODIO_BUILD_VERSION > PODIO_VERSION(0, 99, 0)
-  const auto cellIDstr = m_cellIDHandle.get().value_or("");
-#else
-  const auto cellIDstr = m_cellIDHandle.get();
-#endif
+  const auto cellIDstr = m_cellIDHandle.get("");
+
   if (cellIDstr != cellIDtest) {
-    error() << "ERROR cellID is: " << cellIDstr << endmsg;
+    error() << "ERROR cellID is: " << cellIDstr << "expected (" << cellIDtest << ")" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -19,8 +19,6 @@
 #include "k4FWCoreTest_cellID_reader.h"
 #include "k4FWCoreTest_cellID_writer.h"
 
-#include "podio/podioVersion.h"
-
 DECLARE_COMPONENT(k4FWCoreTest_cellID_reader)
 
 k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName, ISvcLocator* aSvcLoc)


### PR DESCRIPTION
BEGINRELEASENOTES
- Make `MetaDataHandle::get` throw an exception in case the value for the handle is not (yet) available.
- Add `MetaDataHandle::get(T defaultValue)` overload to get a default value and no exception in case the value is not (yet) available.
- Add `MetaDataHandle::get_optional()` to retrieve an optional that is engaged and holds the value if the handle already has a value available.
  - The optional is returned directly from the underlying Frame in case that is available (see  [AIDASoft/podio#580](https://github.com/AIDASoft/podio/pull/580)) or is constructed in place in case it is not yet available.
 
ENDRELEASENOTES

~I have for now opted to let the underlying change in podio shine through here. I think having an `optional` value for `MetaDataHandle::get` offers the same benefits as having it on the `Frame` in the first place, as otherwise there is no way of distinguishing between empty and unset values.~