### PR TITLE
Remove some messages and fix some tests

### DIFF
--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -141,9 +141,8 @@ void IOSvc::handle(const Incident& incident) {
     if (code.isSuccess()) {
       debug() << "Removing the collection: " << coll << " from the store" << endmsg;
       code = m_dataSvc->unregisterObject(collPtr);
-    }
-    else {
-       error() << "Expected collection " << coll << " in the store but it was not found" << endmsg;
+    } else {
+      error() << "Expected collection " << coll << " in the store but it was not found" << endmsg;
     }
   }
 }

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -74,7 +74,6 @@ std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std:
   podio::Frame frame;
   {
     std::scoped_lock<std::mutex> lock(m_changeBufferLock);
-    info() << "m_nextEntry = " << m_nextEntry << " m_entries = " << m_entries << endmsg;
     if (m_nextEntry < m_entries) {
       frame = podio::Frame(std::move(m_reader->readEntry(podio::Category::Event, m_nextEntry)));
     } else {
@@ -88,7 +87,6 @@ std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std:
   }
 
   if (m_nextEntry >= m_entries) {
-    // if (true) {
     auto       ep = serviceLocator()->as<IEventProcessor>();
     StatusCode sc = ep->stopRun();
     if (sc.isFailure()) {
@@ -144,9 +142,9 @@ void IOSvc::handle(const Incident& incident) {
       debug() << "Removing the collection: " << coll << " from the store" << endmsg;
       code = m_dataSvc->unregisterObject(collPtr);
     }
-    // else {
-    //   info() << "Collection not found: " << coll << endmsg;
-    // }
+    else {
+       error() << "Expected collection " << coll << " in the store but it was not found" << endmsg;
+    }
   }
 }
 

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -93,7 +93,6 @@ std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std:
       error() << "Error when stopping run" << endmsg;
       throw GaudiException("Error when stopping run", name(), StatusCode::FAILURE);
     }
-    info() << "m_nextEntry = " << m_nextEntry << " m_entries = " << m_entries << endmsg;
   }
 
   std::vector<std::shared_ptr<podio::CollectionBase>> collections;

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -138,15 +138,17 @@ namespace k4FWCore {
             // 1. a mistake was made in the input types of a functional algorithm
             // 2. the data was produced using the old DataHandle, which is never going to be in the input type
             if (e.message().find("different from") != std::string::npos) {
-              thisClass->error() << "Trying to cast the collection " << std::get<Index>(handles)[0].objKey()
-                                 << " to the requested type " << thisClass->name() << endmsg;
+              thisClass->debug() << "Trying to cast the collection " << std::get<Index>(handles)[0].objKey()
+                                 << " to the requested type didn't work " << endmsg;
               DataObject*       p;
               IDataProviderSvc* svc = thisClass->serviceLocator()->template service<IDataProviderSvc>("EventDataSvc");
               svc->retrieveObject("/Event/" + std::get<Index>(handles)[0].objKey(), p).ignore();
               const auto wrp = dynamic_cast<const DataWrapper<std::tuple_element_t<Index, std::tuple<In...>>>*>(p);
               if (!wrp) {
                 throw GaudiException(thisClass->name(),
-                                     "Failed to cast collection " + std::get<Index>(handles)[0].objKey(),
+                                     "Failed to cast collection " + std::get<Index>(handles)[0].objKey() +
+                                         " to the requested type " +
+                                         typeid(std::tuple_element_t<Index, std::tuple<In...>>).name(),
                                      StatusCode::FAILURE);
               }
               std::get<Index>(inputTuple) = const_cast<std::tuple_element_t<Index, std::tuple<In...>>*>(wrp->getData());

--- a/test/k4FWCoreTest/options/runFunctionalMix.py
+++ b/test/k4FWCoreTest/options/runFunctionalMix.py
@@ -20,7 +20,7 @@
 # This is an example mixing functional and non-functional algorithms
 #
 
-from Gaudi.Configuration import INFO, DEBUG
+from Gaudi.Configuration import INFO
 from Configurables import (
     ExampleFunctionalConsumerMultiple,
     ExampleFunctionalTransformerMultiple,
@@ -102,7 +102,7 @@ consumer_producerfun_functional = ExampleFunctionalConsumerMultiple(
     InputCollectionParticles=["FunctionalMCParticles"],
     Offset=0,
 )
-consumer_producerfun_algorithm = k4FWCoreTest_CheckExampleEventData("CheckFunctional")
+consumer_producerfun_algorithm = k4FWCoreTest_CheckExampleEventData("CheckFunctional", keepEventNumberZero=True)
 consumer_producerfun_algorithm.mcparticles = "FunctionalMCParticles"
 consumer_producerfun_algorithm.keepEventNumberZero = True
 
@@ -125,6 +125,7 @@ consumer_produceralg_functional = ExampleFunctionalConsumerMultiple(
 )
 consumer_produceralg_algorithm = k4FWCoreTest_CheckExampleEventData("CheckAlgorithm")
 consumer_produceralg_algorithm.mcparticles = "OldAlgorithmMCParticles"
+consumer_produceralg_algorithm.vectorfloat = "OldAlgorithmVectorFloat"
 
 ###############################
 
@@ -160,5 +161,5 @@ ApplicationMgr(
     EvtSel="NONE",
     EvtMax=10,
     ExtSvc=[iosvc if args.iosvc else podioevent],
-    OutputLevel=DEBUG,
+    OutputLevel=INFO,
 )

--- a/test/k4FWCoreTest/options/runFunctionalMix.py
+++ b/test/k4FWCoreTest/options/runFunctionalMix.py
@@ -102,7 +102,9 @@ consumer_producerfun_functional = ExampleFunctionalConsumerMultiple(
     InputCollectionParticles=["FunctionalMCParticles"],
     Offset=0,
 )
-consumer_producerfun_algorithm = k4FWCoreTest_CheckExampleEventData("CheckFunctional", keepEventNumberZero=True)
+consumer_producerfun_algorithm = k4FWCoreTest_CheckExampleEventData(
+    "CheckFunctional", keepEventNumberZero=True
+)
 consumer_producerfun_algorithm.mcparticles = "FunctionalMCParticles"
 consumer_producerfun_algorithm.keepEventNumberZero = True
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
@@ -21,17 +21,6 @@
 
 // datamodel
 #include "edm4hep/MCParticleCollection.h"
-#include "edm4hep/SimTrackerHitCollection.h"
-#include "edm4hep/TrackCollection.h"
-#if __has_include("edm4hep/TrackerHit3DCollection.h")
-#include "edm4hep/TrackerHit3DCollection.h"
-#else
-#include "edm4hep/TrackerHitCollection.h"
-namespace edm4hep {
-  using TrackerHit3DCollection = edm4hep::TrackerHitCollection;
-}  // namespace edm4hep
-#endif
-#include "edm4hep/TrackerHitPlaneCollection.h"
 
 DECLARE_COMPONENT(k4FWCoreTest_CheckExampleEventData)
 
@@ -48,9 +37,11 @@ StatusCode k4FWCoreTest_CheckExampleEventData::initialize() { return Gaudi::Algo
 StatusCode k4FWCoreTest_CheckExampleEventData::execute(const EventContext&) const {
   auto floatVector = m_vectorFloatHandle.get();
   if (floatVector->size() != 3 || (*floatVector)[2] != m_event) {
-    fatal() << "Contents of vectorfloat collection is not as expected: size = " << floatVector->size()
-            << " (expected 3), contents = " << *floatVector << " (expected [125., 25., " << m_event << "]) " << endmsg;
-    // return StatusCode::FAILURE;
+    std::stringstream error;
+    error << "Contents of vectorfloat collection is not as expected: size = " << floatVector->size()
+           << " (expected 3), contents = " << *floatVector << " (expected [125., 25., " << m_event << "]) ";
+    throw std::runtime_error(error.str());
+
   }
 
   auto particles = m_mcParticleHandle.get();

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
@@ -39,9 +39,8 @@ StatusCode k4FWCoreTest_CheckExampleEventData::execute(const EventContext&) cons
   if (floatVector->size() != 3 || (*floatVector)[2] != m_event) {
     std::stringstream error;
     error << "Contents of vectorfloat collection is not as expected: size = " << floatVector->size()
-           << " (expected 3), contents = " << *floatVector << " (expected [125., 25., " << m_event << "]) ";
+          << " (expected 3), contents = " << *floatVector << " (expected [125., 25., " << m_event << "]) ";
     throw std::runtime_error(error.str());
-
   }
 
   auto particles = m_mcParticleHandle.get();


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove unnecessary messages (IOSvc saying at which entry we are when reading a file and an error message when a cast doesn't work, which is foreseen and will always happen when a functional algorithm reads something generated by the "old" algorithms), one of them an error message that is not an error
- Fix tests by making a test throw instead of simply outputting an error message

ENDRELEASENOTES