### PR TITLE
Remove the dQ/dx information from the tracks

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -102,12 +102,10 @@ struct ExampleFunctionalConsumerMultiple final
     }
 
     if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3) ||
-        (std::abs(tracks[0].getDEdx() - 4.1) > 1e-6) || (std::abs(tracks[0].getDEdxError() - 5.1) > 1e-6) ||
         (std::abs(tracks[0].getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
       std::stringstream error;
       error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType() << ", "
-            << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", " << tracks[0].getDEdx() << ", "
-            << tracks[0].getDEdxError() << ", " << tracks[0].getRadiusOfInnermostHit() << "";
+            << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", " << tracks[0].getRadiusOfInnermostHit() << "";
       throw std::runtime_error(error.str());
     }
   }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
@@ -71,12 +71,11 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
     }
     for (auto& [key, tracks] : trackMap) {
       if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3) ||
-          (std::abs(tracks[0].getDEdx() - 4.1) > 1e-6) || (std::abs(tracks[0].getDEdxError() - 5.1) > 1e-6) ||
           (std::abs(tracks[0].getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType()
-              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", " << tracks[0].getDEdx() << ", "
-              << tracks[0].getDEdxError() << ", " << tracks[0].getRadiusOfInnermostHit() << "";
+              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", "
+              << tracks[0].getRadiusOfInnermostHit() << "";
         throw std::runtime_error(error.str());
       }
     }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -84,8 +84,6 @@ struct ExampleFunctionalProducerMultiple final : k4FWCore::Producer<retType()> {
     track.setType(1);
     track.setChi2(2.1);
     track.setNdf(3);
-    track.setDEdx(4.1);
-    track.setDEdxError(5.1);
     track.setRadiusOfInnermostHit(6.1);
     track.addToSubdetectorHitNumbers(1);
     track.addToSubdetectorHitNumbers(4);

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -171,13 +171,11 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
     for (auto& [key, tracks] : trackMap) {
       auto coll = edm4hep::TrackCollection();
       if ((tracks.at(0).getType() != 1) || (std::abs(tracks.at(0).getChi2() - 2.1) > 1e-6) ||
-          (tracks.at(0).getNdf() != 3) || (std::abs(tracks.at(0).getDEdx() - 4.1) > 1e-6) ||
-          (std::abs(tracks.at(0).getDEdxError() - 5.1) > 1e-6) ||
-          (std::abs(tracks.at(0).getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+          (tracks.at(0).getNdf() != 3) || (std::abs(tracks.at(0).getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks.at(0).getType()
-              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf() << ", " << tracks.at(0).getDEdx()
-              << ", " << tracks.at(0).getDEdxError() << ", " << tracks.at(0).getRadiusOfInnermostHit() << "";
+              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf() << ", "
+              << tracks.at(0).getRadiusOfInnermostHit() << "";
         throw std::runtime_error(error.str());
       }
       coll->push_back(tracks.at(0).clone());

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -89,8 +89,6 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute(const EventContext&) con
   track.setType(1);
   track.setChi2(2.1);
   track.setNdf(3);
-  track.setDEdx(4.1);
-  track.setDEdxError(5.1);
   track.setRadiusOfInnermostHit(6.1);
   // set vectormembers
 #if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the dQ/dx information from the tracks. Needed after https://github.com/key4hep/EDM4hep/pull/311

ENDRELEASENOTES

Doesn't have any effect downstream since they were used only for tests