### PR TITLE
Use `std::vector` instead of `std::map` for reading or writing an arbitrary number of collections.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,9 +39,9 @@ endif()
 
 # Set up C++ Standard
 # ``-DCMAKE_CXX_STANDARD=<standard>`` when invoking CMake
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "")
 
-if(NOT CMAKE_CXX_STANDARD MATCHES "17|20")
+if(NOT CMAKE_CXX_STANDARD MATCHES "20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -41,8 +41,8 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isMapToCollLike<In>::value) && ...),
-                    "Consumer input types must be EDM4hep collections or maps to collections");
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+                    "Consumer input types must be EDM4hep collections or vectors to collection pointers");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;
@@ -56,7 +56,7 @@ namespace k4FWCore {
 
       template <typename IArgs, std::size_t... I>
       Consumer(std::string name, ISvcLocator* locator, const IArgs& inputs, std::index_sequence<I...>)
-          : base_class(std::move(name), locator),
+        : base_class(std::move(name), locator),
             // The input locations are filled by creating a property with a callback function
             // that creates the handles because that is when the input locations become available
             // (from a steering file, for example) and the handles have to be created for
@@ -71,7 +71,8 @@ namespace k4FWCore {
                   }
                   std::get<I>(m_inputs) = std::move(handles);
                 },
-                Gaudi::Details::Property::ImmediatelyInvokeHandler{true}}...} {}
+                Gaudi::Details::Property::ImmediatelyInvokeHandler{true}}...}
+      {}
 
       Consumer(std::string name, ISvcLocator* locator,
                Gaudi::Functional::details::RepeatValues_<KeyValues, sizeof...(In)> const& inputs)

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -92,7 +92,7 @@ namespace k4FWCore {
       // ... instead, they must implement the following operator
       virtual void operator()(const In&...) const = 0;
 
-      const auto inputLocations(int i) const {
+      auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
           throw GaudiException("Called inputLocations with an index out of range", "Consumer", StatusCode::FAILURE);
         }

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -27,6 +27,7 @@
 
 #include "k4FWCore/FunctionalUtils.h"
 
+#include <ranges>
 #include <type_traits>
 #include <utility>
 
@@ -90,6 +91,13 @@ namespace k4FWCore {
 
       // ... instead, they must implement the following operator
       virtual void operator()(const In&...) const = 0;
+
+      const auto inputLocations(int i) const {
+        if (i >= sizeof...(In)) {
+          throw GaudiException("Called inputLocations with an index out of range", "Consumer", StatusCode::FAILURE);
+        }
+        return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
+      }
     };
 
   }  // namespace details

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -43,7 +43,7 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&& ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
                     "Consumer input types must be EDM4hep collections or vectors of collection pointers");
 
       template <typename T>
@@ -100,7 +100,8 @@ namespace k4FWCore {
        */
       const auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
-          throw std::out_of_range("Called inputLocations with an index out of range");
+          throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
+                                  ", number of inputs: " + std::to_string(sizeof...(In)));
         }
         return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
@@ -110,8 +111,7 @@ namespace k4FWCore {
        * @return      A range of the input locations
        */
       const auto inputLocations(std::string_view name) const {
-        auto it = std::find_if(m_inputLocations.begin(), m_inputLocations.end(),
-                               [&name](const auto& prop) { return prop.name() == name; });
+        auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");
         }

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -41,7 +41,7 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
                     "Consumer input types must be EDM4hep collections or vectors to collection pointers");
 
       template <typename T>
@@ -56,7 +56,7 @@ namespace k4FWCore {
 
       template <typename IArgs, std::size_t... I>
       Consumer(std::string name, ISvcLocator* locator, const IArgs& inputs, std::index_sequence<I...>)
-        : base_class(std::move(name), locator),
+          : base_class(std::move(name), locator),
             // The input locations are filled by creating a property with a callback function
             // that creates the handles because that is when the input locations become available
             // (from a steering file, for example) and the handles have to be created for
@@ -71,8 +71,7 @@ namespace k4FWCore {
                   }
                   std::get<I>(m_inputs) = std::move(handles);
                 },
-                Gaudi::Details::Property::ImmediatelyInvokeHandler{true}}...}
-      {}
+                Gaudi::Details::Property::ImmediatelyInvokeHandler{true}}...} {}
 
       Consumer(std::string name, ISvcLocator* locator,
                Gaudi::Functional::details::RepeatValues_<KeyValues, sizeof...(In)> const& inputs)

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -42,7 +42,7 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
-                    "Consumer input types must be EDM4hep collections or vectors to collection pointers");
+                    "Consumer input types must be EDM4hep collections or vectors of collection pointers");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -43,7 +43,7 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&& ...),
                     "Consumer input types must be EDM4hep collections or vectors of collection pointers");
 
       template <typename T>

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -117,6 +117,7 @@ namespace k4FWCore {
         }
         return it->value() | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
+      static constexpr std::size_t inputLocationsSize() { return sizeof...(In); }
     };
 
   }  // namespace details

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -123,7 +123,7 @@ namespace k4FWCore {
         if constexpr (isVectorLike_v<std::tuple_element_t<Index, std::tuple<In...>>>) {
           // Bare EDM4hep type, without pointers
           using EDM4hepType =
-            std::remove_pointer_t<typename std::tuple_element_t<Index, std::tuple<In...>>::value_type>;
+              std::remove_pointer_t<typename std::tuple_element_t<Index, std::tuple<In...>>::value_type>;
           auto inputMap = std::vector<const EDM4hepType*>();
           for (auto& handle : std::get<Index>(handles)) {
             auto in = get(handle, thisClass, Gaudi::Hive::currentContext());

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -44,7 +44,7 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(
-          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&& ...),
           "Transformer and Producer input types must be EDM4hep collections or vectors of collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors of collections");

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -298,7 +298,7 @@ namespace k4FWCore {
        * @return      A range of the output locations
        */
       const auto outputLocations(std::string_view name) const {
-        auto it = std::find_if(m_outputLocations.begin(), m_outputLocations.end(),
+        auto it = std::ranges::find_if(m_outputLocations.begin(), m_outputLocations.end(),
                                [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_outputLocations.end()) {
           throw std::runtime_error("Called outputLocations with an unknown name");

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -44,7 +44,7 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(
-          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
+          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
           "Transformer and Producer input types must be EDM4hep collections or vectors of collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
@@ -182,9 +182,9 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value)&&...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value) && ...),
                     "Transformer and Producer input types must be EDM4hep collections or maps to collections");
-      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value)&&...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value) && ...),
                     "Transformer and Producer output types must be EDM4hep collections or maps to collections");
 
       template <typename T>
@@ -299,7 +299,7 @@ namespace k4FWCore {
        */
       const auto outputLocations(std::string_view name) const {
         auto it = std::ranges::find_if(m_outputLocations.begin(), m_outputLocations.end(),
-                               [&name](const auto& prop) { return prop.name() == name; });
+                                       [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_outputLocations.end()) {
           throw std::runtime_error("Called outputLocations with an unknown name");
         }

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -44,7 +44,7 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(
-          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
           "Transformer and Producer input types must be EDM4hep collections or vectors of collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors of collections");

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -170,6 +170,7 @@ namespace k4FWCore {
         }
         return m_outputLocations | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
+      static constexpr std::size_t inputLocationsSize() { return sizeof...(In); }
 
       // ... instead, they must implement the following operator
       virtual Out operator()(const In&...) const = 0;
@@ -305,6 +306,8 @@ namespace k4FWCore {
         }
         return it->value() | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
+      static constexpr std::size_t inputLocationsSize() { return sizeof...(In); }
+      static constexpr std::size_t outputLocationsSize() { return sizeof...(Out); }
 
       // ... instead, they must implement the following operator
       virtual std::tuple<Out...> operator()(const In&...) const = 0;

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -41,10 +41,10 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isMapToCollLike<In>::value) && ...),
-                    "Transformer and Producer input types must be EDM4hep collections or maps to collections");
-      static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isMapToCollLike<Out>::value),
-                    "Transformer and Producer output types must be EDM4hep collections or maps to collections");
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+                    "Transformer and Producer input types must be EDM4hep collections or vectors to collection pointers");
+      static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
+                    "Transformer and Producer output types must be EDM4hep collections or vectors to collections");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;
@@ -85,9 +85,6 @@ namespace k4FWCore {
                 this, std::get<J>(outputs).first, to_DataObjID(std::get<J>(outputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
                   std::vector<OutputHandle_t<typename transformType<Out>::type>> h;
-                  // Is this needed?
-                  // std::sort(this->m_outputLocations[J].value().begin(), this->m_outputLocations[J].value().end(),
-                  //           [](const DataObjID& a, const DataObjID& b) { return a.key() < b.key(); });
                   for (auto& inpID : this->m_outputLocations[J].value()) {
                     if (inpID.key().empty()) {
                       continue;
@@ -111,7 +108,7 @@ namespace k4FWCore {
       // derived classes are NOT allowed to implement execute ...
       StatusCode execute(const EventContext& ctx) const override final {
         try {
-          if constexpr (isMapToCollLike<Out>::value) {
+          if constexpr (isVectorLike<Out>::value) {
             std::tuple<Out> tmp = filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs);
             putMapOutputs<0, Out>(std::move(tmp), m_outputs, this);
           } else {
@@ -137,9 +134,9 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isMapToCollLike<In>::value) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value) && ...),
                     "Transformer and Producer input types must be EDM4hep collections or maps to collections");
-      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isMapToCollLike<Out>::value) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value) && ...),
                     "Transformer and Producer output types must be EDM4hep collections or maps to collections");
 
       template <typename T>

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -44,7 +44,7 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(
-          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&& ...),
+          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
           "Transformer and Producer input types must be EDM4hep collections or vectors of collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
@@ -133,7 +133,8 @@ namespace k4FWCore {
        */
       auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
-          throw std::out_of_range("Called inputLocations with an index out of range");
+          throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
+                                  ", number of inputs: " + std::to_string(sizeof...(In)));
         }
         return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
@@ -143,8 +144,7 @@ namespace k4FWCore {
        * @return      A range of the input locations
        */
       const auto inputLocations(std::string_view name) const {
-        auto it = std::find_if(m_inputLocations.begin(), m_inputLocations.end(),
-                               [&name](const auto& prop) { return prop.name() == name; });
+        auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");
         }
@@ -182,9 +182,9 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value)&&...),
                     "Transformer and Producer input types must be EDM4hep collections or maps to collections");
-      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value)&&...),
                     "Transformer and Producer output types must be EDM4hep collections or maps to collections");
 
       template <typename T>
@@ -262,7 +262,8 @@ namespace k4FWCore {
        */
       const auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
-          throw std::out_of_range("Called inputLocations with an index out of range");
+          throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
+                                  ", number of inputs: " + std::to_string(sizeof...(In)));
         }
         return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
@@ -272,8 +273,7 @@ namespace k4FWCore {
        * @return      A range of the input locations
        */
       const auto inputLocations(std::string_view name) const {
-        auto it = std::find_if(m_inputLocations.begin(), m_inputLocations.end(),
-                               [&name](const auto& prop) { return prop.name() == name; });
+        auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");
         }

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -41,8 +41,9 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
-                    "Transformer and Producer input types must be EDM4hep collections or vectors to collection pointers");
+      static_assert(
+          ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
+          "Transformer and Producer input types must be EDM4hep collections or vectors to collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors to collections");
 

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -43,9 +43,9 @@ namespace k4FWCore {
 
       static_assert(
           ((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
-          "Transformer and Producer input types must be EDM4hep collections or vectors to collection pointers");
+          "Transformer and Producer input types must be EDM4hep collections or vectors of collection pointers");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out>),
-                    "Transformer and Producer output types must be EDM4hep collections or vectors to collections");
+                    "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;
@@ -111,7 +111,7 @@ namespace k4FWCore {
         try {
           if constexpr (isVectorLike<Out>::value) {
             std::tuple<Out> tmp = filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs);
-            putMapOutputs<0, Out>(std::move(tmp), m_outputs, this);
+            putVectorOutputs<0, Out>(std::move(tmp), m_outputs, this);
           } else {
             Gaudi::Functional::details::put(
                 std::get<0>(this->m_outputs)[0],
@@ -200,7 +200,7 @@ namespace k4FWCore {
       StatusCode execute(const EventContext& ctx) const override final {
         try {
           auto tmp = filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs);
-          putMapOutputs<0, Out...>(std::move(tmp), m_outputs, this);
+          putVectorOutputs<0, Out...>(std::move(tmp), m_outputs, this);
           return Gaudi::Functional::FilterDecision::PASSED;
         } catch (GaudiException& e) {
           (e.code() ? this->warning() : this->error()) << e.tag() << " : " << e.message() << endmsg;

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -125,14 +125,14 @@ namespace k4FWCore {
         }
       }
 
-      const auto inputLocations(int i) const {
+      auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
           throw GaudiException("Called inputLocations with an index out of range", "Consumer", StatusCode::FAILURE);
         }
         return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
 
-      const auto outputLocations() const {
+      auto outputLocations() const {
         return m_outputLocations | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
 
@@ -220,14 +220,14 @@ namespace k4FWCore {
         }
       }
 
-      const auto inputLocations(int i) const {
+      auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
           throw GaudiException("Called inputLocations with an index out of range", "Consumer", StatusCode::FAILURE);
         }
         return m_inputLocations[i] | std::views::transform([](const DataObjID& id) -> const auto& { return id.key(); });
       }
 
-      const auto outputLocations(int i) const {
+      auto outputLocations(int i) const {
         if (i >= sizeof...(Out)) {
           throw GaudiException("Called outputLocations with an index out of range", "Consumer", StatusCode::FAILURE);
         }

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -18,15 +18,12 @@
  */
 #include "k4FWCore/PodioDataSvc.h"
 #include <GaudiKernel/StatusCode.h>
-#include "GaudiKernel/IConversionSvc.h"
 #include "GaudiKernel/IEventProcessor.h"
 #include "GaudiKernel/IProperty.h"
 #include "GaudiKernel/ISvcLocator.h"
 #include "k4FWCore/DataWrapper.h"
 
 #include "podio/CollectionBase.h"
-
-#include "TTree.h"
 
 /// Service initialisation
 StatusCode PodioDataSvc::initialize() {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
@@ -37,7 +37,12 @@ struct ExampleFunctionalConsumerRuntimeCollections final
     if (input.size() != 3) {
       throw std::runtime_error("Wrong size of the input vector, expected 3, got " + std::to_string(input.size()));
     }
-    auto test = edm4hep::MCParticleCollection();
+    for (int i = 0; i < 3; i++) {
+      if (inputLocations(0)[i] != "MCParticles" + std::to_string(i)) {
+        throw std::runtime_error("Wrong name of the input collection, expected MCParticles" + std::to_string(i) +
+                                 ", got " + std::string(inputLocations(0)[i]));
+      }
+    }
     for (auto& coll : input) {
       int i = 0;
       for (const auto&& particle : *coll) {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
@@ -42,6 +42,12 @@ struct ExampleFunctionalConsumerRuntimeCollections final
         throw std::runtime_error("Wrong name of the input collection, expected MCParticles" + std::to_string(i) +
                                  ", got " + std::string(inputLocations(0)[i]));
       }
+      // Add another redundant check to show that the inputLocations() function
+      // can be called with a name instead of an index
+      if (inputLocations("InputCollection")[i] != "MCParticles" + std::to_string(i)) {
+        throw std::runtime_error("Wrong name of the input collection, expected MCParticles" + std::to_string(i) +
+                                 ", got " + std::string(inputLocations(0)[i]));
+      }
     }
     for (auto& coll : input) {
       int i = 0;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
@@ -27,8 +27,8 @@
 
 struct ExampleFunctionalConsumerRuntimeCollections final
     : k4FWCore::Consumer<void(const std::vector<const edm4hep::MCParticleCollection*>& input)> {
-  // The pair in KeyValues can be changed from python and it corresponds
-  // to the name of the input collections
+  // The pair in KeyValue can be changed from python and it corresponds
+  // to the name of the output collection
   ExampleFunctionalConsumerRuntimeCollections(const std::string& name, ISvcLocator* svcLoc)
       : Consumer(name, svcLoc, KeyValues("InputCollection", {"DefaultValue"})) {}
 

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
@@ -26,20 +26,21 @@
 #include <string>
 
 struct ExampleFunctionalConsumerRuntimeCollections final
-    : k4FWCore::Consumer<void(const std::map<std::string, const edm4hep::MCParticleCollection&>& input)> {
+    : k4FWCore::Consumer<void(const std::vector<const edm4hep::MCParticleCollection*>& input)> {
   // The pair in KeyValues can be changed from python and it corresponds
   // to the name of the input collections
   ExampleFunctionalConsumerRuntimeCollections(const std::string& name, ISvcLocator* svcLoc)
       : Consumer(name, svcLoc, KeyValues("InputCollection", {"DefaultValue"})) {}
 
   // This is the function that will be called to produce the data
-  void operator()(const std::map<std::string, const edm4hep::MCParticleCollection&>& input) const override {
+  void operator()(const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
     if (input.size() != 3) {
-      throw std::runtime_error("Wrong size of the input map, expected 3, got " + std::to_string(input.size()));
+      throw std::runtime_error("Wrong size of the input vector, expected 3, got " + std::to_string(input.size()));
     }
-    for (auto& [key, val] : input) {
+    auto test = edm4hep::MCParticleCollection();
+    for (auto& coll : input) {
       int i = 0;
-      for (const auto& particle : val) {
+      for (const auto&& particle : *coll) {
         if ((particle.getPDG() != 1 + i + m_offset) || (particle.getGeneratorStatus() != 2 + i + m_offset) ||
             (particle.getSimulatorStatus() != 3 + i + m_offset) || (particle.getCharge() != 4 + i + m_offset) ||
             (particle.getTime() != 5 + i + m_offset) || (particle.getMass() != 6 + i + m_offset)) {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
@@ -26,21 +26,21 @@
 #include <string>
 
 struct ExampleFunctionalProducerRuntimeCollections final
-    : k4FWCore::Producer<std::map<std::string, edm4hep::MCParticleCollection>()> {
+    : k4FWCore::Producer<std::vector<edm4hep::MCParticleCollection>()> {
   // The pair in KeyValues can be changed from python and it corresponds
   // to the name of the output collection
   ExampleFunctionalProducerRuntimeCollections(const std::string& name, ISvcLocator* svcLoc)
       : Producer(name, svcLoc, {}, {KeyValues("OutputCollections", {"MCParticles"})}) {}
 
   // This is the function that will be called to produce the data
-  std::map<std::string, edm4hep::MCParticleCollection> operator()() const override {
-    std::map<std::string, edm4hep::MCParticleCollection> outputCollections;
+  std::vector<edm4hep::MCParticleCollection> operator()() const override {
+    std::vector<edm4hep::MCParticleCollection> outputCollections;
     for (int i = 0; i < m_numberOfCollections; ++i) {
       std::string name = "MCParticles" + std::to_string(i);
       auto        coll = edm4hep::MCParticleCollection();
       coll->create(1, 2, 3, 4.f, 5.f, 6.f);
       coll->create(2, 3, 4, 5.f, 6.f, 7.f);
-      outputCollections[name] = std::move(coll);
+      outputCollections.emplace_back(std::move(coll));
     }
     return outputCollections;
   }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
@@ -27,7 +27,7 @@
 
 struct ExampleFunctionalProducerRuntimeCollections final
     : k4FWCore::Producer<std::vector<edm4hep::MCParticleCollection>()> {
-  // The pair in KeyValues can be changed from python and it corresponds
+  // The pair in KeyValue can be changed from python and it corresponds
   // to the name of the output collection
   ExampleFunctionalProducerRuntimeCollections(const std::string& name, ISvcLocator* svcLoc)
       : Producer(name, svcLoc, {}, {KeyValues("OutputCollections", {"MCParticles"})}) {}

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
@@ -38,6 +38,11 @@ struct ExampleFunctionalProducerRuntimeCollections final
       if (locs[i] != "MCParticles" + std::to_string(i)) {
         throw GaudiException("Output collection name does not match the expected one", name(), StatusCode::FAILURE);
       }
+      // Add another redundant check to show that the outputLocations() function
+      // can be called with a name instead of an index
+      if (outputLocations("OutputCollections")[i] != "MCParticles" + std::to_string(i)) {
+        throw GaudiException("Output collection name does not match the expected one", name(), StatusCode::FAILURE);
+      }
       info() << "Creating collection " << i << endmsg;
       auto coll = edm4hep::MCParticleCollection();
       coll->create(1, 2, 3, 4.f, 5.f, 6.f);

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-#include "Gaudi/Property.h"
-
 #include "edm4hep/MCParticleCollection.h"
 
 #include "k4FWCore/Producer.h"
@@ -34,22 +32,20 @@ struct ExampleFunctionalProducerRuntimeCollections final
 
   // This is the function that will be called to produce the data
   std::vector<edm4hep::MCParticleCollection> operator()() const override {
+    const auto                                 locs = outputLocations();
     std::vector<edm4hep::MCParticleCollection> outputCollections;
-    for (int i = 0; i < m_numberOfCollections; ++i) {
-      std::string name = "MCParticles" + std::to_string(i);
-      auto        coll = edm4hep::MCParticleCollection();
+    for (size_t i = 0; i < locs.size(); ++i) {
+      if (locs[i] != "MCParticles" + std::to_string(i)) {
+        throw GaudiException("Output collection name does not match the expected one", name(), StatusCode::FAILURE);
+      }
+      info() << "Creating collection " << i << endmsg;
+      auto coll = edm4hep::MCParticleCollection();
       coll->create(1, 2, 3, 4.f, 5.f, 6.f);
       coll->create(2, 3, 4, 5.f, 6.f, 7.f);
       outputCollections.emplace_back(std::move(coll));
     }
     return outputCollections;
   }
-
-private:
-  // We can define any property we want that can be set from python
-  // and use it inside operator()
-  Gaudi::Property<int> m_numberOfCollections{this, "NumberOfCollections", 3,
-                                             "Example int that can be used in the algorithm"};
 };
 
 DECLARE_COMPONENT(ExampleFunctionalProducerRuntimeCollections)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
@@ -35,7 +35,7 @@
 struct ExampleFunctionalTransformerRuntimeCollections final
     : k4FWCore::Transformer<std::vector<edm4hep::MCParticleCollection>(
           const std::vector<const edm4hep::MCParticleCollection*>& input)> {
-  // The pair in KeyValues can be changed from python and it corresponds
+  // The pair in KeyValue can be changed from python and it corresponds
   // to the name of the output collection
   ExampleFunctionalTransformerRuntimeCollections(const std::string& name, ISvcLocator* svcLoc)
       : Transformer(name, svcLoc, {KeyValues("InputCollections", {"MCParticles"})},

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -31,16 +31,15 @@
 #include <string>
 
 // Which type of collection we are reading
-using FloatColl         = std::map<std::string, const podio::UserDataCollection<float>&>;
-using ParticleColl      = std::map<std::string, const edm4hep::MCParticleCollection&>;
-using SimTrackerHitColl = std::map<std::string, const edm4hep::SimTrackerHitCollection&>;
-using TrackerHitColl    = std::map<std::string, const edm4hep::TrackerHit3DCollection&>;
-using TrackColl         = std::map<std::string, const edm4hep::TrackCollection&>;
+using FloatColl         = std::vector<const podio::UserDataCollection<float>*>;
+using ParticleColl      = std::vector<const edm4hep::MCParticleCollection*>;
+using SimTrackerHitColl = std::vector<const edm4hep::SimTrackerHitCollection*>;
+using TrackerHitColl    = std::vector<const edm4hep::TrackerHit3DCollection*>;
+using TrackColl         = std::vector<const edm4hep::TrackCollection*>;
 
-using retType = std::tuple<
-    std::map<std::string, podio::UserDataCollection<float>>, std::map<std::string, edm4hep::MCParticleCollection>,
-    std::map<std::string, edm4hep::MCParticleCollection>, std::map<std::string, edm4hep::SimTrackerHitCollection>,
-    std::map<std::string, edm4hep::TrackerHit3DCollection>, std::map<std::string, edm4hep::TrackCollection>>;
+using retType = std::tuple<std::vector<podio::UserDataCollection<float>>, std::vector<edm4hep::MCParticleCollection>,
+                           std::vector<edm4hep::MCParticleCollection>, std::vector<edm4hep::SimTrackerHitCollection>,
+                           std::vector<edm4hep::TrackerHit3DCollection>, std::vector<edm4hep::TrackCollection>>;
 
 struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
     : k4FWCore::MultiTransformer<retType(const FloatColl&, const ParticleColl&, const SimTrackerHitColl&,
@@ -68,47 +67,52 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
   // This is the function that will be called to transform the data
   // Note that the function has to be const, as well as the collections
   // we get from the input
-  retType operator()(const FloatColl& floatMap, const ParticleColl& particlesMap,
-                     const SimTrackerHitColl& simTrackerHitMap, const TrackerHitColl& trackerHitMap,
-                     const TrackColl& trackMap) const override {
-    auto floatMapOut         = std::map<std::string, podio::UserDataCollection<float>>();
-    auto particleMapOut      = std::map<std::string, edm4hep::MCParticleCollection>();
-    auto particle2MapOut     = std::map<std::string, edm4hep::MCParticleCollection>();
-    auto simTrackerHitMapOut = std::map<std::string, edm4hep::SimTrackerHitCollection>();
-    auto trackerHitMapOut    = std::map<std::string, edm4hep::TrackerHit3DCollection>();
-    auto trackMapOut         = std::map<std::string, edm4hep::TrackCollection>();
+  retType operator()(const FloatColl& floatVec, const ParticleColl& particlesVec,
+                     const SimTrackerHitColl& simTrackerHitVec, const TrackerHitColl& trackerHitVec,
+                     const TrackColl& trackVec) const override {
+    auto floatVecOut         = std::vector<podio::UserDataCollection<float>>();
+    auto particleVecOut      = std::vector<edm4hep::MCParticleCollection>();
+    auto particle2VecOut     = std::vector<edm4hep::MCParticleCollection>();
+    auto simTrackerHitVecOut = std::vector<edm4hep::SimTrackerHitCollection>();
+    auto trackerHitVecOut    = std::vector<edm4hep::TrackerHit3DCollection>();
+    auto trackVecOut         = std::vector<edm4hep::TrackCollection>();
 
-    if (floatMap.size() != 3) {
-      throw std::runtime_error("Wrong size of the floatVector collection map, expected 3, got " +
-                               std::to_string(floatMap.size()) + "");
+    if (floatVec.size() != 3) {
+      throw std::runtime_error("Wrong size of the float vector, expected 3, got " + std::to_string(floatVec.size()) +
+                               "");
     }
-    for (const auto& [key, floatVector] : floatMap) {
-      if (floatVector.size() != 3) {
+    for (const auto& floatVector : floatVec) {
+      if (floatVector->size() != 3) {
         throw std::runtime_error("Wrong size of floatVector collection, expected 3, got " +
-                                 std::to_string(floatVector.size()) + "");
+                                 std::to_string(floatVector->size()) + "");
       }
-      if ((floatVector.vec()[0] != 125) || (floatVector.vec()[1] != 25) || (floatVector.vec()[2] != 0)) {
+      if ((floatVector->vec()[0] != 125) || (floatVector->vec()[1] != 25) || (floatVector->vec()[2] != 0)) {
         std::stringstream error;
+<<<<<<< HEAD
         error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector.vec()[0]
               << ", " << floatVector.vec()[1] << ", " << floatVector.vec()[2];
+=======
+        error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector->vec()[0]
+              << ", " << floatVector->vec()[1] << ", " << floatVector->vec()[2] << "";
+>>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
       auto coll = podio::UserDataCollection<float>();
-      coll.push_back(floatVector.vec()[0]);
-      coll.push_back(floatVector.vec()[1]);
-      coll.push_back(floatVector.vec()[2]);
-      floatMapOut["New" + key] = std::move(coll);
+      coll.push_back(floatVector->vec()[0]);
+      coll.push_back(floatVector->vec()[1]);
+      coll.push_back(floatVector->vec()[2]);
+      floatVecOut.emplace_back(std::move(coll));
     }
 
-    if (particlesMap.size() != 3) {
-      throw std::runtime_error("Wrong size of the particleMap map, expected 3, got " +
-                               std::to_string(particleMapOut.size()) + "");
+    if (particlesVec.size() != 3) {
+      throw std::runtime_error("Wrong size of the particle vector, expected 3, got " +
+                               std::to_string(particleVecOut.size()) + "");
     }
 
-    for (auto& [key, particles] : particlesMap) {
+    for (auto& particles : particlesVec) {
       auto coll = edm4hep::MCParticleCollection();
       int  i    = 0;
-      for (const auto& particle : particles) {
+      for (const auto& particle : *particles) {
         if ((particle.getPDG() != 1 + i + m_offset) || (particle.getGeneratorStatus() != 2 + i + m_offset) ||
             (particle.getSimulatorStatus() != 3 + i + m_offset) || (particle.getCharge() != 4 + i + m_offset) ||
             (particle.getTime() != 5 + i + m_offset) || (particle.getMass() != 6 + i + m_offset)) {
@@ -122,67 +126,81 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
           coll.push_back(particle.clone());
         }
         i++;
-        particleMapOut["New" + key] = std::move(coll);
       }
+      particleVecOut.emplace_back(std::move(coll));
     }
 
-    if (simTrackerHitMap.size() != 3) {
-      throw std::runtime_error("Wrong size of the simTrackerHitMap map, expected 3, got " +
-                               std::to_string(simTrackerHitMapOut.size()) + "");
+    if (simTrackerHitVec.size() != 3) {
+      throw std::runtime_error("Wrong size of the simTrackerHit vector, expected 3, got " +
+                               std::to_string(simTrackerHitVecOut.size()) + "");
     }
 
-    for (auto& [key, simTrackerHits] : simTrackerHitMap) {
+    for (auto& simTrackerHits : simTrackerHitVec) {
       auto coll = edm4hep::SimTrackerHitCollection();
-      if ((simTrackerHits.at(0).getPosition()[0] != 3) || (simTrackerHits.at(0).getPosition()[1] != 4) ||
-          (simTrackerHits.at(0).getPosition()[2] != 5)) {
+      if ((simTrackerHits->at(0).getPosition()[0] != 3) || (simTrackerHits->at(0).getPosition()[1] != 4) ||
+          (simTrackerHits->at(0).getPosition()[2] != 5)) {
         std::stringstream error;
         error << "Wrong data in simTrackerHits collection, expected 3, 4, 5 got "
-              << simTrackerHits.at(0).getPosition()[0] << ", " << simTrackerHits.at(0).getPosition()[1] << ", "
-              << simTrackerHits.at(0).getPosition()[2];
+              << simTrackerHits->at(0).getPosition()[0] << ", " << simTrackerHits->at(0).getPosition()[1] << ", "
+              << simTrackerHits->at(0).getPosition()[2];
         throw std::runtime_error(error.str());
       }
-      coll.push_back(simTrackerHits.at(0).clone());
-      simTrackerHitMapOut["New" + key] = std::move(coll);
+      coll.push_back(simTrackerHits->at(0).clone());
+      simTrackerHitVecOut.emplace_back(std::move(coll));
     }
 
-    if (trackerHitMap.size() != 3) {
-      throw std::runtime_error("Wrong size of the trackerHitMap map, expected 3, got " +
-                               std::to_string(trackerHitMapOut.size()) + "");
+    if (trackerHitVec.size() != 3) {
+      throw std::runtime_error("Wrong size of the trackerHit vector, expected 3, got " +
+                               std::to_string(trackerHitVecOut.size()) + "");
     }
 
-    for (auto& [key, trackerHits] : trackerHitMap) {
+    for (auto& trackerHits : trackerHitVec) {
       auto coll = edm4hep::TrackerHit3DCollection();
-      if ((trackerHits.at(0).getPosition()[0] != 3) || (trackerHits.at(0).getPosition()[1] != 4) ||
-          (trackerHits.at(0).getPosition()[2] != 5)) {
+      if ((trackerHits->at(0).getPosition()[0] != 3) || (trackerHits->at(0).getPosition()[1] != 4) ||
+          (trackerHits->at(0).getPosition()[2] != 5)) {
         std::stringstream error;
+<<<<<<< HEAD
         error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits.at(0).getPosition()[0]
               << ", " << trackerHits.at(0).getPosition()[1] << ", " << trackerHits.at(0).getPosition()[2];
+=======
+        error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits->at(0).getPosition()[0]
+              << ", " << trackerHits->at(0).getPosition()[1] << ", " << trackerHits->at(0).getPosition()[2] << "";
+>>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
-      coll.push_back(trackerHits.at(0).clone());
-      trackerHitMapOut["New" + key] = std::move(coll);
+      coll.push_back(trackerHits->at(0).clone());
+      trackerHitVecOut.emplace_back(std::move(coll));
     }
 
-    if (trackMap.size() != 3) {
-      throw std::runtime_error("Wrong size of the trackMap map, expected 3, got " + std::to_string(trackMapOut.size()) +
+    if (trackVec.size() != 3) {
+      throw std::runtime_error("Wrong size of the track vector, expected 3, got " + std::to_string(trackVecOut.size()) +
                                "");
     }
 
-    for (auto& [key, tracks] : trackMap) {
+    for (auto& tracks : trackVec) {
       auto coll = edm4hep::TrackCollection();
+<<<<<<< HEAD
       if ((tracks.at(0).getType() != 1) || (std::abs(tracks.at(0).getChi2() - 2.1) > 1e-6) ||
           (tracks.at(0).getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks.at(0).getType()
               << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf();
+=======
+      if ((tracks->at(0).getType() != 1) || (std::abs(tracks->at(0).getChi2() - 2.1) > 1e-6) ||
+          (tracks->at(0).getNdf() != 3) || (std::abs(tracks->at(0).getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+        std::stringstream error;
+        error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks->at(0).getType()
+              << ", " << tracks->at(0).getChi2() << ", " << tracks->at(0).getNdf() << ", "
+              << tracks->at(0).getRadiusOfInnermostHit() << "";
+>>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
-      coll->push_back(tracks.at(0).clone());
-      trackMapOut["New" + key] = std::move(coll);
+      coll->push_back(tracks->at(0).clone());
+      trackVecOut.emplace_back(std::move(coll));
     }
 
-    return std::make_tuple(std::move(floatMapOut), std::move(particleMapOut), std::move(particle2MapOut),
-                           std::move(simTrackerHitMapOut), std::move(trackerHitMapOut), std::move(trackMapOut));
+    return std::make_tuple(std::move(floatVecOut), std::move(particleVecOut), std::move(particle2VecOut),
+                           std::move(simTrackerHitVecOut), std::move(trackerHitVecOut), std::move(trackVecOut));
   }
 
 private:

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -88,13 +88,8 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
       }
       if ((floatVector->vec()[0] != 125) || (floatVector->vec()[1] != 25) || (floatVector->vec()[2] != 0)) {
         std::stringstream error;
-<<<<<<< HEAD
-        error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector.vec()[0]
-              << ", " << floatVector.vec()[1] << ", " << floatVector.vec()[2];
-=======
         error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector->vec()[0]
               << ", " << floatVector->vec()[1] << ", " << floatVector->vec()[2] << "";
->>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
       auto coll = podio::UserDataCollection<float>();
@@ -159,13 +154,8 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
       if ((trackerHits->at(0).getPosition()[0] != 3) || (trackerHits->at(0).getPosition()[1] != 4) ||
           (trackerHits->at(0).getPosition()[2] != 5)) {
         std::stringstream error;
-<<<<<<< HEAD
-        error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits.at(0).getPosition()[0]
-              << ", " << trackerHits.at(0).getPosition()[1] << ", " << trackerHits.at(0).getPosition()[2];
-=======
         error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits->at(0).getPosition()[0]
               << ", " << trackerHits->at(0).getPosition()[1] << ", " << trackerHits->at(0).getPosition()[2] << "";
->>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
       coll.push_back(trackerHits->at(0).clone());
@@ -179,20 +169,12 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
 
     for (auto& tracks : trackVec) {
       auto coll = edm4hep::TrackCollection();
-<<<<<<< HEAD
-      if ((tracks.at(0).getType() != 1) || (std::abs(tracks.at(0).getChi2() - 2.1) > 1e-6) ||
-          (tracks.at(0).getNdf() != 3)) {
-        std::stringstream error;
-        error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks.at(0).getType()
-              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf();
-=======
       if ((tracks->at(0).getType() != 1) || (std::abs(tracks->at(0).getChi2() - 2.1) > 1e-6) ||
-          (tracks->at(0).getNdf() != 3) || (std::abs(tracks->at(0).getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+          (tracks->at(0).getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks->at(0).getType()
               << ", " << tracks->at(0).getChi2() << ", " << tracks->at(0).getNdf() << ", "
               << tracks->at(0).getRadiusOfInnermostHit() << "";
->>>>>>> a8b3276 (Use std::vector instead of std::map for reading or writing an)
         throw std::runtime_error(error.str());
       }
       coll->push_back(tracks->at(0).clone());

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -173,8 +173,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
           (tracks->at(0).getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks->at(0).getType()
-              << ", " << tracks->at(0).getChi2() << ", " << tracks->at(0).getNdf() << ", "
-              << tracks->at(0).getRadiusOfInnermostHit() << "";
+              << ", " << tracks->at(0).getChi2() << ", " << tracks->at(0).getNdf();
         throw std::runtime_error(error.str());
       }
       coll->push_back(tracks->at(0).clone());

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
@@ -29,13 +29,11 @@
  *
  * This is an example of a functional transformer that takes an arbitrary number
  * of input collections and produces an arbitrary number of output collections
- * but it's returning an empty map (no output collections)
+ * but it's returning an empty vector (no output collections)
  */
 
-using mapType = std::map<std::string, const edm4hep::MCParticleCollection&>;
-
 struct ExampleFunctionalTransformerRuntimeEmpty final
-    : k4FWCore::Transformer<std::map<std::string, edm4hep::MCParticleCollection>(const mapType& input)> {
+    : k4FWCore::Transformer<std::vector<edm4hep::MCParticleCollection>(const std::vector<const edm4hep::MCParticleCollection*>& input)> {
   // The pair in KeyValues can be changed from python and it corresponds
   // to the name of the output collections
   ExampleFunctionalTransformerRuntimeEmpty(const std::string& name, ISvcLocator* svcLoc)
@@ -43,9 +41,9 @@ struct ExampleFunctionalTransformerRuntimeEmpty final
                     {KeyValues("OutputCollections", {"MCParticles"})}) {}
 
   // This is the function that will be called to produce the data
-  std::map<std::string, edm4hep::MCParticleCollection> operator()(const mapType& input) const override {
-    // We just return an empty map to make sure it works fine
-    std::map<std::string, edm4hep::MCParticleCollection> outputCollections;
+   std::vector<edm4hep::MCParticleCollection> operator()(const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
+    // Return an empty vector to make sure that also works
+    std::vector<edm4hep::MCParticleCollection> outputCollections;
     return outputCollections;
   }
 

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
@@ -33,7 +33,8 @@
  */
 
 struct ExampleFunctionalTransformerRuntimeEmpty final
-    : k4FWCore::Transformer<std::vector<edm4hep::MCParticleCollection>(const std::vector<const edm4hep::MCParticleCollection*>& input)> {
+    : k4FWCore::Transformer<std::vector<edm4hep::MCParticleCollection>(
+          const std::vector<const edm4hep::MCParticleCollection*>& input)> {
   // The pair in KeyValues can be changed from python and it corresponds
   // to the name of the output collections
   ExampleFunctionalTransformerRuntimeEmpty(const std::string& name, ISvcLocator* svcLoc)
@@ -41,7 +42,8 @@ struct ExampleFunctionalTransformerRuntimeEmpty final
                     {KeyValues("OutputCollections", {"MCParticles"})}) {}
 
   // This is the function that will be called to produce the data
-   std::vector<edm4hep::MCParticleCollection> operator()(const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
+  std::vector<edm4hep::MCParticleCollection> operator()(
+      const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
     // Return an empty vector to make sure that also works
     std::vector<edm4hep::MCParticleCollection> outputCollections;
     return outputCollections;


### PR DESCRIPTION
The current implementation with std::map is not easy to use. The collections get ordered alphabetically in std::map so the order set in the steering file is lost, which means if there is some kind of mapping (like one output collection for each input collection) then one has to reproduce this map in the algorithm and the way I found to do it is to have another property with the input and output names again. For output one creates the collections and then puts them in a vector, I think it can't get simpler than that. For input, since there can't be vectors to references one gets a pointer to the collection, which is not ideal but not so bad. With a custom type it would be possible to have a vector that when using [] can get a reference but then that introduces a custom type which I don't like.

BEGINRELEASENOTES

- FunctionalAlgorithms: Use std::vector instead of std::map for input or output an arbitrary number of collections.
- Add an `inputLocations` and `outputLocations` methods to be able to retrieve the locations set in the steering file.

ENDRELEASENOTES