### PR TITLE
Don't use `radiusOfInnermostHit` from EDM4hep tracks

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumer.cpp
@@ -51,7 +51,7 @@ struct ExampleFunctionalConsumer final : k4FWCore::Consumer<void(const edm4hep::
               << ", " << 3 + i + m_offset << ", " << 4 + i + m_offset << ", " << 5 + i + m_offset << ", "
               << 6 + i + m_offset << " got " << particle.getPDG() << ", " << particle.getGeneratorStatus() << ", "
               << particle.getSimulatorStatus() << ", " << particle.getCharge() << ", " << particle.getTime() << ", "
-              << particle.getMass() << "";
+              << particle.getMass();
         throw std::runtime_error(error.str());
       }
       i++;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -101,11 +101,10 @@ struct ExampleFunctionalConsumerMultiple final
       throw std::runtime_error(error.str());
     }
 
-    if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3) ||
-        (std::abs(tracks[0].getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+    if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3)) {
       std::stringstream error;
       error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType() << ", "
-            << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", " << tracks[0].getRadiusOfInnermostHit() << "";
+            << tracks[0].getChi2() << ", " << tracks[0].getNdf() << "";
       throw std::runtime_error(error.str());
     }
   }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultiple.cpp
@@ -65,7 +65,7 @@ struct ExampleFunctionalConsumerMultiple final
     if ((floatVector[0] != 125) || (floatVector[1] != 25) || (floatVector[2] != 0)) {
       std::stringstream error;
       error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector[0] << ", "
-            << floatVector[1] << ", " << floatVector[2] << "";
+            << floatVector[1] << ", " << floatVector[2];
       throw std::runtime_error(error.str());
     }
 
@@ -79,7 +79,7 @@ struct ExampleFunctionalConsumerMultiple final
               << ", " << 3 + i + m_offset << ", " << 4 + i + m_offset << ", " << 5 + i + m_offset << ", "
               << 6 + i + m_offset << " got " << particle.getPDG() << ", " << particle.getGeneratorStatus() << ", "
               << particle.getSimulatorStatus() << ", " << particle.getCharge() << ", " << particle.getTime() << ", "
-              << particle.getMass() << "";
+              << particle.getMass();
         throw std::runtime_error(error.str());
       }
       i++;
@@ -89,7 +89,7 @@ struct ExampleFunctionalConsumerMultiple final
         (simTrackerHits[0].getPosition()[2] != 5)) {
       std::stringstream error;
       error << "Wrong data in simTrackerHits collection, expected 3, 4, 5 got " << simTrackerHits[0].getPosition()[0]
-            << ", " << simTrackerHits[0].getPosition()[1] << ", " << simTrackerHits[0].getPosition()[2] << "";
+            << ", " << simTrackerHits[0].getPosition()[1] << ", " << simTrackerHits[0].getPosition()[2];
       throw std::runtime_error(error.str());
     }
 
@@ -97,14 +97,14 @@ struct ExampleFunctionalConsumerMultiple final
         (trackerHits[0].getPosition()[2] != 5)) {
       std::stringstream error;
       error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits[0].getPosition()[0] << ", "
-            << trackerHits[0].getPosition()[1] << ", " << trackerHits[0].getPosition()[2] << "";
+            << trackerHits[0].getPosition()[1] << ", " << trackerHits[0].getPosition()[2];
       throw std::runtime_error(error.str());
     }
 
     if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3)) {
       std::stringstream error;
       error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType() << ", "
-            << tracks[0].getChi2() << ", " << tracks[0].getNdf() << "";
+            << tracks[0].getChi2() << ", " << tracks[0].getNdf();
       throw std::runtime_error(error.str());
     }
   }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
@@ -48,7 +48,7 @@ struct ExampleFunctionalConsumerRuntimeCollections final
                 << ", " << 3 + i + m_offset << ", " << 4 + i + m_offset << ", " << 5 + i + m_offset << ", "
                 << 6 + i + m_offset << " got " << particle.getPDG() << ", " << particle.getGeneratorStatus() << ", "
                 << particle.getSimulatorStatus() << ", " << particle.getCharge() << ", " << particle.getTime() << ", "
-                << particle.getMass() << "";
+                << particle.getMass();
           throw std::runtime_error(error.str());
         }
         i++;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
@@ -60,7 +60,7 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
                 << ", " << 3 + i + m_offset << ", " << 4 + i + m_offset << ", " << 5 + i + m_offset << ", "
                 << 6 + i + m_offset << " got " << particle.getPDG() << ", " << particle.getGeneratorStatus() << ", "
                 << particle.getSimulatorStatus() << ", " << particle.getCharge() << ", " << particle.getTime() << ", "
-                << particle.getMass() << "";
+                << particle.getMass();
           throw std::runtime_error(error.str());
         }
         i++;
@@ -73,7 +73,7 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
       if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType()
-              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf() << "";
+              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf();
         throw std::runtime_error(error.str());
       }
     }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
@@ -70,12 +70,10 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
       fatal() << "Wrong size of the tracks map, expected 3, got " << trackMap.size() << endmsg;
     }
     for (auto& [key, tracks] : trackMap) {
-      if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3) ||
-          (std::abs(tracks[0].getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+      if ((tracks[0].getType() != 1) || (std::abs(tracks[0].getChi2() - 2.1) > 1e-6) || (tracks[0].getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks[0].getType()
-              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf() << ", "
-              << tracks[0].getRadiusOfInnermostHit() << "";
+              << ", " << tracks[0].getChi2() << ", " << tracks[0].getNdf() << "";
         throw std::runtime_error(error.str());
       }
     }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -84,7 +84,6 @@ struct ExampleFunctionalProducerMultiple final : k4FWCore::Producer<retType()> {
     track.setType(1);
     track.setChi2(2.1);
     track.setNdf(3);
-    track.setRadiusOfInnermostHit(6.1);
     track.addToSubdetectorHitNumbers(1);
     track.addToSubdetectorHitNumbers(4);
     track.addToTrackStates(edm4hep::TrackState());

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -171,11 +171,10 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
     for (auto& [key, tracks] : trackMap) {
       auto coll = edm4hep::TrackCollection();
       if ((tracks.at(0).getType() != 1) || (std::abs(tracks.at(0).getChi2() - 2.1) > 1e-6) ||
-          (tracks.at(0).getNdf() != 3) || (std::abs(tracks.at(0).getRadiusOfInnermostHit() - 6.1) > 1e-6)) {
+          (tracks.at(0).getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks.at(0).getType()
-              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf() << ", "
-              << tracks.at(0).getRadiusOfInnermostHit() << "";
+              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf() << "";
         throw std::runtime_error(error.str());
       }
       coll->push_back(tracks.at(0).clone());

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -90,7 +90,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
       if ((floatVector.vec()[0] != 125) || (floatVector.vec()[1] != 25) || (floatVector.vec()[2] != 0)) {
         std::stringstream error;
         error << "Wrong data in floatVector collection, expected 125, 25, " << 0 << " got " << floatVector.vec()[0]
-              << ", " << floatVector.vec()[1] << ", " << floatVector.vec()[2] << "";
+              << ", " << floatVector.vec()[1] << ", " << floatVector.vec()[2];
         throw std::runtime_error(error.str());
       }
       auto coll = podio::UserDataCollection<float>();
@@ -117,7 +117,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
                 << ", " << 3 + i + m_offset << ", " << 4 + i + m_offset << ", " << 5 + i + m_offset << ", "
                 << 6 + i + m_offset << " got " << particle.getPDG() << ", " << particle.getGeneratorStatus() << ", "
                 << particle.getSimulatorStatus() << ", " << particle.getCharge() << ", " << particle.getTime() << ", "
-                << particle.getMass() << "";
+                << particle.getMass();
           throw std::runtime_error(error.str());
           coll.push_back(particle.clone());
         }
@@ -138,7 +138,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
         std::stringstream error;
         error << "Wrong data in simTrackerHits collection, expected 3, 4, 5 got "
               << simTrackerHits.at(0).getPosition()[0] << ", " << simTrackerHits.at(0).getPosition()[1] << ", "
-              << simTrackerHits.at(0).getPosition()[2] << "";
+              << simTrackerHits.at(0).getPosition()[2];
         throw std::runtime_error(error.str());
       }
       coll.push_back(simTrackerHits.at(0).clone());
@@ -156,7 +156,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
           (trackerHits.at(0).getPosition()[2] != 5)) {
         std::stringstream error;
         error << "Wrong data in trackerHits collection, expected 3, 4, 5 got " << trackerHits.at(0).getPosition()[0]
-              << ", " << trackerHits.at(0).getPosition()[1] << ", " << trackerHits.at(0).getPosition()[2] << "";
+              << ", " << trackerHits.at(0).getPosition()[1] << ", " << trackerHits.at(0).getPosition()[2];
         throw std::runtime_error(error.str());
       }
       coll.push_back(trackerHits.at(0).clone());
@@ -174,7 +174,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
           (tracks.at(0).getNdf() != 3)) {
         std::stringstream error;
         error << "Wrong data in tracks collection, expected 1, 2.1, 3, 4.1, 5.1, 6.1 got " << tracks.at(0).getType()
-              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf() << "";
+              << ", " << tracks.at(0).getChi2() << ", " << tracks.at(0).getNdf();
         throw std::runtime_error(error.str());
       }
       coll->push_back(tracks.at(0).clone());

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -89,7 +89,6 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute(const EventContext&) con
   track.setType(1);
   track.setChi2(2.1);
   track.setNdf(3);
-  track.setRadiusOfInnermostHit(6.1);
   // set vectormembers
 #if EDM4HEP_BUILD_VERSION > EDM4HEP_VERSION(0, 9, 0)
   track.addToSubdetectorHitNumbers(1);


### PR DESCRIPTION
see https://github.com/key4hep/EDM4hep/pull/326. Can be merged at any time, doesn't need https://github.com/key4hep/EDM4hep/pull/326 first.


BEGINRELEASENOTES
- Don't use `radiusOfInnermostHit` from EDM4hep tracks

ENDRELEASENOTES