### PR TITLE
Ensure ROOT is in batch mode

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -6,7 +6,6 @@ import argparse
 import logging
 
 from k4FWCore.utils import load_file
-from ROOT import gROOT
 
 # these default properties are filtered as otherwise they will clutter the argument list
 FILTER_GAUDI_PROPS = [
@@ -149,6 +148,12 @@ def main():
         help="Print all the configurable components available in the framework and exit",
     )
     parser.add_argument("--gdb", action="store_true", help="Attach gdb debugger")
+    parser.add_argument(
+        "--disableROOTBatchMode",
+        action="store_true",
+        help="Do not enforce ROOT batch mode",
+        default=False,
+    )
 
     # Once to parse the files and another time below to have the new parameters
     # in the namespace since parsing of the file happens when the namespace
@@ -230,8 +235,11 @@ def main():
 
     c = gaudimain()
     if not opts.dry_run:
-        # ensure ROOT runs in batch mode
-        gROOT.SetBatch(True)
+        if not opts.disableROOTBatchMode:
+            # ensure ROOT runs in batch mode
+            from ROOT import gROOT
+
+            gROOT.SetBatch(True)
 
         # Do the real processing
         retcode = c.run(opts.gdb)

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -149,7 +149,7 @@ def main():
     )
     parser.add_argument("--gdb", action="store_true", help="Attach gdb debugger")
     parser.add_argument(
-        "--disableROOTBatchMode",
+        "--interactive-root",
         action="store_true",
         help="Do not enforce ROOT batch mode",
         default=False,
@@ -235,7 +235,7 @@ def main():
 
     c = gaudimain()
     if not opts.dry_run:
-        if not opts.disableROOTBatchMode:
+        if not opts.interactive_root:
             from ROOT import gROOT
             gROOT.SetBatch(True)
 

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -236,9 +236,7 @@ def main():
     c = gaudimain()
     if not opts.dry_run:
         if not opts.disableROOTBatchMode:
-            # ensure ROOT runs in batch mode
             from ROOT import gROOT
-
             gROOT.SetBatch(True)
 
         # Do the real processing

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -6,6 +6,7 @@ import argparse
 import logging
 
 from k4FWCore.utils import load_file
+from ROOT import gROOT
 
 # these default properties are filtered as otherwise they will clutter the argument list
 FILTER_GAUDI_PROPS = [
@@ -229,6 +230,9 @@ def main():
 
     c = gaudimain()
     if not opts.dry_run:
+        # ensure ROOT runs in batch mode
+        gROOT.SetBatch(True)
+
         # Do the real processing
         retcode = c.run(opts.gdb)
         # User requested stop returns non-zero exit code see: https://github.com/key4hep/k4FWCore/issues/125

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -237,6 +237,7 @@ def main():
     if not opts.dry_run:
         if not opts.interactive_root:
             from ROOT import gROOT
+
             gROOT.SetBatch(True)
 
         # Do the real processing

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -151,7 +151,7 @@ def main():
     parser.add_argument(
         "--interactive-root",
         action="store_true",
-        help="Do not enforce ROOT batch mode",
+        help="Run with ROOT in interactive mode (e.g. to see plots)",
         default=False,
     )
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Ensure ROOT is in batch mode by setting `gROOT.SetBatch(True)` in `k4run`

ENDRELEASENOTES

Basically an upstream of https://github.com/key4hep/CLDConfig/pull/36 as there will probably also be some other processors that are affected.