### PR TITLE
Add a filter algorithm

### DIFF
--- a/k4FWCore/include/k4FWCore/FilterPredicate.h
+++ b/k4FWCore/include/k4FWCore/FilterPredicate.h
@@ -25,4 +25,3 @@ namespace k4FWCore {
   template <typename Signature>
   using FilterPredicate = Gaudi::Functional::FilterPredicate<Signature, details::BaseClass_t>;
 }
-

--- a/k4FWCore/include/k4FWCore/FilterPredicate.h
+++ b/k4FWCore/include/k4FWCore/FilterPredicate.h
@@ -1,0 +1,10 @@
+
+#include "Gaudi/Functional/FilterPredicate.h"
+#include "k4FWCore/FunctionalUtils.h"
+
+namespace k4FWCore {
+
+  template <typename Signature>
+  using FilterPredicate = Gaudi::Functional::FilterPredicate<Signature, details::BaseClass_t>;
+}
+

--- a/k4FWCore/include/k4FWCore/FilterPredicate.h
+++ b/k4FWCore/include/k4FWCore/FilterPredicate.h
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "Gaudi/Functional/FilterPredicate.h"
 #include "k4FWCore/FunctionalUtils.h"

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -50,8 +50,10 @@ namespace k4FWCore {
     }
 
     template <typename T, typename P>
-    requires (!std::is_same_v<P, std::shared_ptr<podio::CollectionBase>>)
-    const auto& maybeTransformToEDM4hep(const P& arg) { return arg; }
+      requires(!std::is_same_v<P, std::shared_ptr<podio::CollectionBase>>)
+    const auto& maybeTransformToEDM4hep(const P& arg) {
+      return arg;
+    }
 
     template <typename T, typename P>
       requires std::is_base_of_v<podio::CollectionBase, P>

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -28,6 +28,7 @@
 
 #include "GaudiKernel/EventContext.h"
 #include "GaudiKernel/ThreadLocalContext.h"
+#include "GaudiKernel/DataObjectHandle.h"
 
 // #include "GaudiKernel/CommonMessaging.h"
 
@@ -42,13 +43,15 @@ namespace k4FWCore {
   namespace details {
 
     // This function will be used to modify std::shared_ptr<podio::CollectionBase> to the actual collection type
-    template <typename T, typename P> auto maybeTransformToEDM4hep(P& arg) { return arg; }
-
     template <typename T, typename P>
       requires std::same_as<P, std::vector<std::string, std::shared_ptr<podio::CollectionBase>>>
     auto maybeTransformToEDM4hep(P& arg) {
       return arg;
     }
+
+    template <typename T, typename P>
+    requires (!std::is_same_v<P, std::shared_ptr<podio::CollectionBase>>)
+    const auto& maybeTransformToEDM4hep(const P& arg) { return arg; }
 
     template <typename T, typename P>
       requires std::is_base_of_v<podio::CollectionBase, P>
@@ -215,6 +218,47 @@ namespace k4FWCore {
       std::transform(in.begin(), in.end(), std::back_inserter(out), [](const std::string& i) { return DataObjID{i}; });
       return out;
     }
+
+    // Functional handles
+    template <typename T>
+    class FunctionalDataObjectReadHandle : public ::details::ReadHandle<T> {
+      template <typename... Args, std::size_t... Is>
+      FunctionalDataObjectReadHandle( std::tuple<Args...>&& args, std::index_sequence<Is...> )
+          : FunctionalDataObjectReadHandle( std::get<Is>( std::move( args ) )... ) {}
+
+    public:
+      /// Autodeclaring constructor with property name, mode, key and documentation.
+      /// @note the use std::enable_if is required to avoid ambiguities
+      template <typename OWNER, typename K, typename = std::enable_if_t<std::is_base_of_v<IProperty, OWNER>>>
+      FunctionalDataObjectReadHandle( OWNER* owner, std::string propertyName, K key = {}, std::string doc = "" )
+          : ::details::ReadHandle<T>( owner, Gaudi::DataHandle::Reader, std::move( propertyName ), std::move( key ),
+                                      std::move( doc ) ) {}
+
+      template <typename... Args>
+      FunctionalDataObjectReadHandle( std::tuple<Args...>&& args )
+          : FunctionalDataObjectReadHandle( std::move( args ), std::index_sequence_for<Args...>{} ) {}
+
+      const T& get() const;
+    };
+
+    template <typename T>
+    const T& FunctionalDataObjectReadHandle<T>::get( ) const {
+      auto dataObj = this->fetch();
+      if ( !dataObj ) {
+        throw GaudiException( "Cannot retrieve \'" + this->objKey() + "\' from transient store.",
+                              this->m_owner ? this->owner()->name() : "no owner", StatusCode::FAILURE );
+      }
+      auto ptr = dynamic_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>( dataObj );
+      return maybeTransformToEDM4hep<T>( ptr->getData() );
+    }
+
+    struct BaseClass_t {
+      template <typename T> using InputHandle  = FunctionalDataObjectReadHandle<T>;
+      // template <typename T> using OutputHandle = DataObjectWriteHandle<T>;
+
+      using BaseClass = Gaudi::Algorithm;
+    };
+
 
   }  // namespace details
 }  // namespace k4FWCore

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -26,9 +26,9 @@
 #include "k4FWCore/DataWrapper.h"
 #include "podio/CollectionBase.h"
 
+#include "GaudiKernel/DataObjectHandle.h"
 #include "GaudiKernel/EventContext.h"
 #include "GaudiKernel/ThreadLocalContext.h"
-#include "GaudiKernel/DataObjectHandle.h"
 
 // #include "GaudiKernel/CommonMessaging.h"
 
@@ -220,45 +220,42 @@ namespace k4FWCore {
     }
 
     // Functional handles
-    template <typename T>
-    class FunctionalDataObjectReadHandle : public ::details::ReadHandle<T> {
+    template <typename T> class FunctionalDataObjectReadHandle : public ::details::ReadHandle<T> {
       template <typename... Args, std::size_t... Is>
-      FunctionalDataObjectReadHandle( std::tuple<Args...>&& args, std::index_sequence<Is...> )
-          : FunctionalDataObjectReadHandle( std::get<Is>( std::move( args ) )... ) {}
+      FunctionalDataObjectReadHandle(std::tuple<Args...>&& args, std::index_sequence<Is...>)
+          : FunctionalDataObjectReadHandle(std::get<Is>(std::move(args))...) {}
 
     public:
       /// Autodeclaring constructor with property name, mode, key and documentation.
       /// @note the use std::enable_if is required to avoid ambiguities
       template <typename OWNER, typename K, typename = std::enable_if_t<std::is_base_of_v<IProperty, OWNER>>>
-      FunctionalDataObjectReadHandle( OWNER* owner, std::string propertyName, K key = {}, std::string doc = "" )
-          : ::details::ReadHandle<T>( owner, Gaudi::DataHandle::Reader, std::move( propertyName ), std::move( key ),
-                                      std::move( doc ) ) {}
+      FunctionalDataObjectReadHandle(OWNER* owner, std::string propertyName, K key = {}, std::string doc = "")
+          : ::details::ReadHandle<T>(owner, Gaudi::DataHandle::Reader, std::move(propertyName), std::move(key),
+                                     std::move(doc)) {}
 
       template <typename... Args>
-      FunctionalDataObjectReadHandle( std::tuple<Args...>&& args )
-          : FunctionalDataObjectReadHandle( std::move( args ), std::index_sequence_for<Args...>{} ) {}
+      FunctionalDataObjectReadHandle(std::tuple<Args...>&& args)
+          : FunctionalDataObjectReadHandle(std::move(args), std::index_sequence_for<Args...>{}) {}
 
       const T& get() const;
     };
 
-    template <typename T>
-    const T& FunctionalDataObjectReadHandle<T>::get( ) const {
+    template <typename T> const T& FunctionalDataObjectReadHandle<T>::get() const {
       auto dataObj = this->fetch();
-      if ( !dataObj ) {
-        throw GaudiException( "Cannot retrieve \'" + this->objKey() + "\' from transient store.",
-                              this->m_owner ? this->owner()->name() : "no owner", StatusCode::FAILURE );
+      if (!dataObj) {
+        throw GaudiException("Cannot retrieve \'" + this->objKey() + "\' from transient store.",
+                             this->m_owner ? this->owner()->name() : "no owner", StatusCode::FAILURE);
       }
-      auto ptr = dynamic_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>( dataObj );
-      return maybeTransformToEDM4hep<T>( ptr->getData() );
+      auto ptr = dynamic_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>(dataObj);
+      return maybeTransformToEDM4hep<T>(ptr->getData());
     }
 
     struct BaseClass_t {
-      template <typename T> using InputHandle  = FunctionalDataObjectReadHandle<T>;
+      template <typename T> using InputHandle = FunctionalDataObjectReadHandle<T>;
       // template <typename T> using OutputHandle = DataObjectWriteHandle<T>;
 
       using BaseClass = Gaudi::Algorithm;
     };
-
 
   }  // namespace details
 }  // namespace k4FWCore

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -108,6 +108,9 @@ add_test_with_env(Testk4runVerboseOutput options/TestArgs.py --verbose PROPERTIE
 add_test_with_env(Testk4runHelpOnly options/TestArgs.py --help PROPERTIES PASS_REGULAR_EXPRESSION "show this help message and exit")
 
 
+# WARNING: If test names are changed, they also need to be changed below for the dependencies of
+# the FunctionalCheckFiles test
+
 add_test_with_env(FunctionalMemory options/ExampleFunctionalMemory.py)
 add_test_with_env(FunctionalMTMemory options/ExampleFunctionalMTMemory.py)
 add_test_with_env(FunctionalMultipleMemory options/ExampleFunctionalMultipleMemory.py)
@@ -131,9 +134,10 @@ add_test_with_env(FunctionalTransformerRuntimeEmpty options/ExampleFunctionalTra
 add_test_with_env(FunctionalTransformerRuntimeCollectionsMultiple options/ExampleFunctionalTransformerRuntimeCollectionsMultiple.py)
 add_test_with_env(FunctionalTransformerHist options/ExampleFunctionalTransformerHist.py)
 add_test_with_env(FunctionalCollectionMerger options/ExampleFunctionalCollectionMerger.py)
+add_test_with_env(FunctionalFilterFile options/ExampleFunctionalFilterFile.py)
 
 add_test(NAME FunctionalCheckFiles COMMAND python3 ${CMAKE_CURRENT_LIST_DIR}/options/CheckOutputFiles.py)
-set_tests_properties(FunctionalCheckFiles PROPERTIES DEPENDS "FunctionalFile;FunctionalMTFile;FunctionalMultipleFile;FunctionalOutputCommands;FunctionalProducerAbsolutePath;FunctionalTransformerRuntimeEmpty;FunctionalMix;FunctionalMixIOSvc;FunctionalTransformerHist;FunctionalCollectionMerger")
+set_tests_properties(FunctionalCheckFiles PROPERTIES DEPENDS "FunctionalFile;FunctionalMTFile;FunctionalMultipleFile;FunctionalOutputCommands;FunctionalProducerAbsolutePath;FunctionalTransformerRuntimeEmpty;FunctionalMix;FunctionalMixIOSvc;FunctionalTransformerHist;FunctionalCollectionMerger;FunctionalFilterFile")
 
 # Do this after checking the files not to overwrite them
 add_test_with_env(FunctionalFile_toolong options/ExampleFunctionalFile.py -n 999 PROPERTIES DEPENDS FunctionalCheckFiles PASS_REGULAR_EXPRESSION

--- a/test/k4FWCoreTest/options/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/options/CheckOutputFiles.py
@@ -44,6 +44,14 @@ def check_collections(filename, names):
             )
             raise RuntimeError("Collections in frame do not match expected collections")
 
+def check_events(filename, number):
+    print(f'Checking file "{filename}" for {number} events')
+    podio_reader = podio.root_io.Reader(filename)
+    frames = podio_reader.get("events")
+    if len(frames) != number:
+        print(f"File {filename} has {len(frames)} events but {number} are expected")
+        raise RuntimeError("Number of events does not match expected number")
+
 
 check_collections("functional_transformer.root", ["MCParticles", "NewMCParticles"])
 check_collections(
@@ -140,3 +148,8 @@ frames = podio_reader.get("events")
 ev = frames[0]
 if len(ev.get("NewMCParticles")) != 4:
     raise RuntimeError(f"Expected 4 NewMCParticles but got {len(ev.get('NewMCParticles'))}")
+
+check_events(
+    "functional_filter.root",
+    5,
+)

--- a/test/k4FWCoreTest/options/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/options/CheckOutputFiles.py
@@ -44,6 +44,7 @@ def check_collections(filename, names):
             )
             raise RuntimeError("Collections in frame do not match expected collections")
 
+
 def check_events(filename, number):
     print(f'Checking file "{filename}" for {number} events')
     podio_reader = podio.root_io.Reader(filename)

--- a/test/k4FWCoreTest/options/ExampleFunctionalFilterFile.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalFilterFile.py
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an creating some collections and filtering after
+# to check that the contents of the file are the expected ones
+
+from Gaudi.Configuration import INFO
+from Configurables import (
+    ExampleFunctionalTransformer,
+    ExampleFunctionalProducer,
+    ExampleFunctionalFilter,
+)
+from k4FWCore import ApplicationMgr, IOSvc
+from Configurables import EventDataSvc
+
+iosvc = IOSvc("IOSvc")
+iosvc.output = "functional_filter.root"
+
+transformer = ExampleFunctionalTransformer(
+    "Transformer", InputCollection=["MCParticles"], OutputCollection=["NewMCParticles"]
+)
+
+producer = ExampleFunctionalProducer("Producer", OutputCollection=["MCParticles"])
+
+filt = ExampleFunctionalFilter(
+    "Filter",
+    InputCollection="NewMCParticles",
+)
+
+ApplicationMgr(
+    TopAlg=[producer, transformer, filt],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
@@ -47,7 +47,6 @@ struct ExampleFunctionalFilter final : k4FWCore::FilterPredicate<bool(const edm4
 
   // Thread-safe counter
   mutable Gaudi::Accumulators::Counter<> m_counter{this, "Counter"};
-
 };
 
 DECLARE_COMPONENT(ExampleFunctionalFilter)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Gaudi/Accumulators.h"
+#include "edm4hep/MCParticleCollection.h"
+
+#include "k4FWCore/FilterPredicate.h"
+
+#include <string>
+
+struct ExampleFunctionalFilter final : k4FWCore::FilterPredicate<bool(const edm4hep::MCParticleCollection& input)> {
+  // The pair in KeyValue can be changed from python and it corresponds
+  // to the name of the input collection
+  ExampleFunctionalFilter(const std::string& name, ISvcLocator* svcLoc)
+      : FilterPredicate(name, svcLoc, KeyValue("InputCollection", {"MCParticles"})) {}
+
+  // This is the function that will be called to check if the event passes
+  // Note that the function has to be const, as well as the collections
+  // we get from the input
+  bool operator()(const edm4hep::MCParticleCollection& input) const override {
+    ++m_counter;
+    // Only pass for half of the events
+    bool condition = m_counter.sum() % 2;
+    if (condition) {
+      info() << "Event passed" << endmsg;
+    } else {
+      info() << "Event did not pass" << endmsg;
+    }
+    return condition;
+  }
+
+  // Thread-safe counter
+  mutable Gaudi::Accumulators::Counter<> m_counter{this, "Counter"};
+
+};
+
+DECLARE_COMPONENT(ExampleFunctionalFilter)


### PR DESCRIPTION
that uses `PredicateFilter` from Gaudi. It doesn't read any number of collections, so passing `std::vector<>` will not compile.

BEGINRELEASENOTES
- Add a filter algorithm, using the `PredicateFilter` algorithm from Gaudi.
- Add the minimum handle needed to be able to use the filter from Gaudi and make it work with the rest of the functional algorithms
- Add a test using this filter

ENDRELEASENOTES

@kjvbrt may be interested