### PR TITLE
harmonise two noise tool interfaces

### DIFF
--- a/k4Interface/include/k4Interface/ICaloReadCellNoiseMap.h
+++ b/k4Interface/include/k4Interface/ICaloReadCellNoiseMap.h
@@ -24,7 +24,7 @@
 
 /** @class ICaloReadCellNoiseMap RecInterface/RecInterface/ICaloReadCellNoiseMap.h ICaloReadCellNoiseMap.h
  *
- *  Abstarct Interface to noise per Calorimeter cell.
+ *  Abstract interface for tools that read noise values (RMS and offset) per calorimeter cell
  *
  *  @author Coralie Neubueser
  */
@@ -36,4 +36,4 @@ public:
   virtual double noiseRMS(uint64_t aCellId)    = 0;
   virtual double noiseOffset(uint64_t aCellId) = 0;
 };
-#endif /* RECINTERFACE_ICALOREADNEIGHBOURSMAP_H */
+#endif /* RECINTERFACE_ICALOREADCELLNOISEMAP_H */

--- a/k4Interface/include/k4Interface/INoiseCaloCellsTool.h
+++ b/k4Interface/include/k4Interface/INoiseCaloCellsTool.h
@@ -24,7 +24,7 @@
 
 /** @class INoiseCaloCellsTool
  *
- *  Abstract interface to calorimeter noise tool
+ *  Abstract interface for tools that add or filter noise to calorimeter cells
  *
  *  @author Jana Faltova
  *  @date   2016-09

--- a/k4Interface/include/k4Interface/INoiseConstTool.h
+++ b/k4Interface/include/k4Interface/INoiseConstTool.h
@@ -24,7 +24,7 @@
 
 /** @class INoiseConstTool
  *
- *  Abstract interface to get calorimeter noise per cell tool
+ *  Abstract interface to get calorimeter noise constants (RMS and offset) per cell tool
  *  @author Coralie Neubueser
  *  @date   2018-01
  */
@@ -33,7 +33,7 @@ class INoiseConstTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(INoiseConstTool, 1, 0);
 
-  virtual double getNoiseConstantPerCell(uint64_t aCellID) = 0;
+  virtual double getNoiseRMSPerCell(uint64_t aCellID) = 0;
   virtual double getNoiseOffsetPerCell(uint64_t aCellID)   = 0;
 };
 

--- a/k4Interface/include/k4Interface/INoiseConstTool.h
+++ b/k4Interface/include/k4Interface/INoiseConstTool.h
@@ -24,7 +24,7 @@
 
 /** @class INoiseConstTool
  *
- *  Abstract interface to get calorimeter noise constants (RMS and offset) per cell tool
+ *  Abstract interface for tools that return noise values (RMS and offset) per calorimeter cell
  *  @author Coralie Neubueser
  *  @date   2018-01
  */

--- a/k4Interface/include/k4Interface/INoiseConstTool.h
+++ b/k4Interface/include/k4Interface/INoiseConstTool.h
@@ -33,8 +33,8 @@ class INoiseConstTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(INoiseConstTool, 1, 0);
 
-  virtual double getNoiseRMSPerCell(uint64_t aCellID) = 0;
-  virtual double getNoiseOffsetPerCell(uint64_t aCellID)   = 0;
+  virtual double getNoiseRMSPerCell(uint64_t aCellID)    = 0;
+  virtual double getNoiseOffsetPerCell(uint64_t aCellID) = 0;
 };
 
 #endif /* RECINTERFACE_INOISECONSTTOOL_H */


### PR DESCRIPTION
BEGINRELEASENOTES
- renamed NoiseConstant by NoiseRMS in the noise interfaces (ICaloReadCellNoiseMap, INoiseCaloCellsTool.h and INoiseConstTool.h) to make its physical meaning clearer

ENDRELEASENOTES

Should be merged only when https://github.com/HEP-FCC/k4RecCalorimeter/pull/98 is reviewed/approved and ready to be merged in cascade, which will fix the few occurrences in the code where the method of the interface which changed name is changed (https://github.com/search?q=getNoiseConstantPerCell&type=code)