### PR TITLE
Fix wrong error message when using std::map as input or output with

### DIFF
--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -44,10 +44,10 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
-                    "Transformer and Producer input types must be EDM4hep collections or maps to collections");
+                    "Transformer and Producer input types must be EDM4hep collections or vectors of collections");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out> ||
                      std::is_same_v<std::shared_ptr<podio::CollectionBase>, Out>),
-                    "Transformer and Producer output types must be EDM4hep collections or maps to collections");
+                    "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;
@@ -184,9 +184,9 @@ namespace k4FWCore {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
       static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value) && ...),
-                    "Transformer and Producer input types must be EDM4hep collections or maps to collections");
+                    "Transformer and Producer input types must be EDM4hep collections or vectors of collections");
       static_assert(((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike<Out>::value) && ...),
-                    "Transformer and Producer output types must be EDM4hep collections or maps to collections");
+                    "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
 
       template <typename T>
       using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix wrong error message when using std::map as input or output with transformers

ENDRELEASENOTES