### PR TITLE
Fix warnings when warnings are enabled

### DIFF
--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -90,7 +90,7 @@ std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std:
   {
     std::scoped_lock<std::mutex> lock(m_changeBufferLock);
     if (m_nextEntry < m_entries) {
-      frame = podio::Frame(std::move(m_reader->readEntry(podio::Category::Event, m_nextEntry)));
+      frame = podio::Frame(m_reader->readEntry(podio::Category::Event, m_nextEntry));
     } else {
       return std::make_tuple(std::vector<std::shared_ptr<podio::CollectionBase>>(), std::vector<std::string>(),
                              std::move(frame));

--- a/k4FWCore/components/Reader.cpp
+++ b/k4FWCore/components/Reader.cpp
@@ -53,7 +53,7 @@ public:
         m_inputCollections{this,
                            "InputCollections",
                            {"Event"},
-                           [this](Gaudi::Details::PropertyBase& b) {
+                           [this](Gaudi::Details::PropertyBase&) {
                              const std::string cmd = System::cmdLineArgs()[0];
                              if (cmd.find("genconf") != std::string::npos) {
                                return;

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -167,7 +167,6 @@ public:
       //   continue;
       // }
       m_availableCollections.insert(pReg->name().substr(1, pReg->name().size() - 1));
-      const std::string& id = pReg->identifier();
     }
   }
 

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -98,7 +98,7 @@ namespace k4FWCore {
        * @param i  The index of the input
        * @return   A range of the input locations
        */
-      const auto inputLocations(int i) const {
+      auto inputLocations(unsigned i) const {
         if (i >= sizeof...(In)) {
           throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
                                   ", number of inputs: " + std::to_string(sizeof...(In)));
@@ -110,7 +110,7 @@ namespace k4FWCore {
        * @param name  The name of the input
        * @return      A range of the input locations
        */
-      const auto inputLocations(std::string_view name) const {
+      auto inputLocations(std::string_view name) const {
         auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -131,7 +131,7 @@ namespace k4FWCore {
        * @param i  The index of the input
        * @return   A range of the input locations
        */
-      auto inputLocations(int i) const {
+      auto inputLocations(unsigned i) const {
         if (i >= sizeof...(In)) {
           throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
                                   ", number of inputs: " + std::to_string(sizeof...(In)));
@@ -143,7 +143,7 @@ namespace k4FWCore {
        * @param name  The name of the input
        * @return      A range of the input locations
        */
-      const auto inputLocations(std::string_view name) const {
+      auto inputLocations(std::string_view name) const {
         auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");
@@ -164,7 +164,7 @@ namespace k4FWCore {
        * @param name  The name of the output
        * @return      A range of the output locations
        */
-      const auto outputLocations(std::string_view name) const {
+      auto outputLocations(std::string_view name) const {
         if (name != m_outputLocations.name()) {
           throw std::runtime_error("Called outputLocations with an unknown name");
         }
@@ -261,7 +261,7 @@ namespace k4FWCore {
        * @param i  The index of the input
        * @return   A range of the input locations
        */
-      const auto inputLocations(int i) const {
+      auto inputLocations(int i) const {
         if (i >= sizeof...(In)) {
           throw std::out_of_range("Called inputLocations with an index out of range, index: " + std::to_string(i) +
                                   ", number of inputs: " + std::to_string(sizeof...(In)));
@@ -273,7 +273,7 @@ namespace k4FWCore {
        * @param name  The name of the input
        * @return      A range of the input locations
        */
-      const auto inputLocations(std::string_view name) const {
+      auto inputLocations(std::string_view name) const {
         auto it = std::ranges::find_if(m_inputLocations, [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_inputLocations.end()) {
           throw std::runtime_error("Called inputLocations with an unknown name");
@@ -298,7 +298,7 @@ namespace k4FWCore {
        * @param name  The name of the output
        * @return      A range of the output locations
        */
-      const auto outputLocations(std::string_view name) const {
+      auto outputLocations(std::string_view name) const {
         auto it = std::ranges::find_if(m_outputLocations.begin(), m_outputLocations.end(),
                                        [&name](const auto& prop) { return prop.name() == name; });
         if (it == m_outputLocations.end()) {

--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -55,10 +55,10 @@ struct ExampleEventHeaderConsumer final : k4FWCore::Consumer<void(const edm4hep:
     }
   }
 
-  Gaudi::Property<int>          m_runNumber{this, "runNumber", 0, "The expected run number"};
-  Gaudi::Property<int>          m_eventNumberOffset{this, "eventNumberOffset", 0,
+  Gaudi::Property<int>              m_runNumber{this, "runNumber", 0, "The expected run number"};
+  Gaudi::Property<int>              m_eventNumberOffset{this, "eventNumberOffset", 0,
                                            "The event number offset where events will start counting from"};
-  mutable std::atomic<unsigned> m_evtCounter{0};
+  mutable std::atomic<std::int32_t> m_evtCounter{0};
 };
 
 DECLARE_COMPONENT(ExampleEventHeaderConsumer)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
@@ -42,6 +42,8 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
   void operator()(const std::vector<const edm4hep::MCParticleCollection*>& particleVec,
                   const std::vector<const edm4hep::TrackCollection*>&      trackVec,
                   const edm4hep::SimTrackerHitCollection&                  simTrackerHits) const override {
+    // Silence warning about unused variable
+    (void)simTrackerHits;
     info() << "Received " << particleVec.size() << " particle collections and " << trackVec.size()
            << " track collections" << endmsg;
     if (particleVec.size() != 5) {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
@@ -41,9 +41,7 @@ struct ExampleFunctionalConsumerRuntimeCollectionsMultiple final
   // This is the function that will be called to produce the data
   void operator()(const std::vector<const edm4hep::MCParticleCollection*>& particleVec,
                   const std::vector<const edm4hep::TrackCollection*>&      trackVec,
-                  const edm4hep::SimTrackerHitCollection&                  simTrackerHits) const override {
-    // Silence warning about unused variable
-    (void)simTrackerHits;
+                  const edm4hep::SimTrackerHitCollection&) const override {
     info() << "Received " << particleVec.size() << " particle collections and " << trackVec.size()
            << " track collections" << endmsg;
     if (particleVec.size() != 5) {

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalFilter.cpp
@@ -33,7 +33,7 @@ struct ExampleFunctionalFilter final : k4FWCore::FilterPredicate<bool(const edm4
   // This is the function that will be called to check if the event passes
   // Note that the function has to be const, as well as the collections
   // we get from the input
-  bool operator()(const edm4hep::MCParticleCollection& input) const override {
+  bool operator()(const edm4hep::MCParticleCollection&) const override {
     ++m_counter;
     // Only pass for half of the events
     bool condition = m_counter.sum() % 2;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataConsumer.cpp
@@ -61,7 +61,7 @@ struct ExampleFunctionalMetadataConsumer final : k4FWCore::Consumer<void(const e
   void operator()(const edm4hep::MCParticleCollection& input) const override {
     // Check that it's possible to get metadata parameters from the main loop
     auto particleNum = k4FWCore::getParameter<int>("NumberOfParticles", this).value_or(-1);
-    if (input.size() != particleNum) {
+    if (input.size() != (size_t)particleNum) {
       error() << "Input MCParticleCollection size is not " << particleNum << endmsg;
       return;
     }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
@@ -45,7 +45,7 @@ struct ExampleFunctionalTransformerRuntimeCollections final
   std::vector<edm4hep::MCParticleCollection> operator()(
       const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
     std::vector<edm4hep::MCParticleCollection> outputCollections;
-    for (int i = 0; i < input.size(); ++i) {
+    for (size_t i = 0; i < input.size(); ++i) {
       std::string name     = "NewMCParticles" + std::to_string(i);
       auto&       old_coll = input.at(i);
       auto        coll     = edm4hep::MCParticleCollection();

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
@@ -43,7 +43,7 @@ struct ExampleFunctionalTransformerRuntimeEmpty final
 
   // This is the function that will be called to produce the data
   std::vector<edm4hep::MCParticleCollection> operator()(
-      const std::vector<const edm4hep::MCParticleCollection*>& input) const override {
+      const std::vector<const edm4hep::MCParticleCollection*>&) const override {
     // Return an empty vector to make sure that also works
     std::vector<edm4hep::MCParticleCollection> outputCollections;
     return outputCollections;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -40,6 +40,8 @@ StatusCode k4FWCoreTest_cellID_reader::initialize() {
 
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
+  // Silence warning because we don't use simtrackerhits_coll
+  (void)simtrackerhits_coll;
 
   const auto cellIDstr = m_cellIDHandle.get();
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -39,9 +39,7 @@ StatusCode k4FWCoreTest_cellID_reader::initialize() {
 }
 
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
-  const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
-  // Silence warning because we don't use simtrackerhits_coll
-  (void)simtrackerhits_coll;
+  [[maybe_unused]] const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
   const auto cellIDstr = m_cellIDHandle.get();
 


### PR DESCRIPTION
I was compiling k4Reco and getting warnings about files in k4FWCore and it turns out that warnings are not enabled in k4FWCore but are in k4Reco. I propose a general solution for all the Key4hep repositories in https://github.com/key4hep/key4hep-dev-utils/pull/5 so feel free to have a look and comment.


BEGINRELEASENOTES
- Fix warnings when warnings are enabled. Warnings will be enabled later.

ENDRELEASENOTES