### PR TITLE
fix virtual specifiers, remove redundant methods, unclutter

### DIFF
--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -121,7 +121,7 @@ private:
   void mergeCollections(const std::shared_ptr<podio::CollectionBase>& source,
                         std::shared_ptr<podio::CollectionBase>&       ret) const {
     if (!ret) {
-      ret.reset(new T());
+      ret = std::make_shared<T>();
       if (!m_copy) {
         ret->setSubsetCollection();
       }

--- a/k4FWCore/components/EventHeaderCreator.cpp
+++ b/k4FWCore/components/EventHeaderCreator.cpp
@@ -26,12 +26,6 @@ EventHeaderCreator::EventHeaderCreator(const std::string& name, ISvcLocator* svc
                   "Name of the EventHeaderCollection that will be stored in the output root file.");
 }
 
-StatusCode EventHeaderCreator::initialize() {
-  if (Gaudi::Algorithm::initialize().isFailure())
-    return StatusCode::FAILURE;
-  return StatusCode::SUCCESS;
-}
-
 StatusCode EventHeaderCreator::execute(const EventContext&) const {
   static int eventNumber = 0;
   debug() << "Filling EventHeader with runNumber " << int(m_runNumber) << " and eventNumber "
@@ -40,11 +34,5 @@ StatusCode EventHeaderCreator::execute(const EventContext&) const {
   auto header  = headers->create();
   header.setRunNumber(m_runNumber);
   header.setEventNumber(eventNumber++ + m_eventNumberOffset);
-  return StatusCode::SUCCESS;
-}
-
-StatusCode EventHeaderCreator::finalize() {
-  if (Gaudi::Algorithm::finalize().isFailure())
-    return StatusCode::FAILURE;
   return StatusCode::SUCCESS;
 }

--- a/k4FWCore/components/EventHeaderCreator.h
+++ b/k4FWCore/components/EventHeaderCreator.h
@@ -34,9 +34,7 @@ class EventHeaderCreator : public Gaudi::Algorithm {
 public:
   EventHeaderCreator(const std::string& name, ISvcLocator* svcLoc);
 
-  StatusCode initialize() override;
   StatusCode execute(const EventContext&) const override;
-  StatusCode finalize() override;
 
 private:
   // Run number value (fixed for the entire job, to be set by the job submitter)

--- a/k4FWCore/components/EventHeaderCreator.h
+++ b/k4FWCore/components/EventHeaderCreator.h
@@ -34,9 +34,9 @@ class EventHeaderCreator : public Gaudi::Algorithm {
 public:
   EventHeaderCreator(const std::string& name, ISvcLocator* svcLoc);
 
-  StatusCode initialize();
-  StatusCode execute(const EventContext&) const;
-  StatusCode finalize();
+  StatusCode initialize() override;
+  StatusCode execute(const EventContext&) const override;
+  StatusCode finalize() override;
 
 private:
   // Run number value (fixed for the entire job, to be set by the job submitter)

--- a/k4FWCore/components/FCCDataSvc.cpp
+++ b/k4FWCore/components/FCCDataSvc.cpp
@@ -28,6 +28,3 @@ FCCDataSvc::FCCDataSvc(const std::string& name, ISvcLocator* svc) : PodioDataSvc
   declareProperty("inputs", m_filenames = {}, "Names of the files to read");
   declareProperty("input", m_filename = "", "Name of the file to read");
 }
-
-/// Standard Destructor
-FCCDataSvc::~FCCDataSvc() {}

--- a/k4FWCore/components/FCCDataSvc.h
+++ b/k4FWCore/components/FCCDataSvc.h
@@ -27,8 +27,5 @@ class FCCDataSvc : public PodioDataSvc {
 public:
   /// Standard Constructor
   FCCDataSvc(const std::string& name, ISvcLocator* svc);
-
-  /// Standard Destructor
-  virtual ~FCCDataSvc();
 };
 #endif

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -40,8 +40,6 @@ class IOSvc : public extends<Service, IIOSvc, IIncidentListener> {
   using extends::extends;
 
 public:
-  ~IOSvc() override = default;
-
   StatusCode initialize() override;
   StatusCode finalize() override;
 

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -25,6 +25,8 @@
 #include <GaudiKernel/IDataProviderSvc.h>
 #include <GaudiKernel/Service.h>
 
+#include <memory>
+
 StatusCode MetadataSvc::initialize() {
   StatusCode sc = Service::initialize();
   if (sc.isFailure()) {
@@ -37,13 +39,13 @@ StatusCode MetadataSvc::initialize() {
     return StatusCode::FAILURE;
   }
 
-  m_frame.reset(new podio::Frame());
+  m_frame = std::make_unique<podio::Frame>();
 
   return StatusCode::SUCCESS;
 }
 
 StatusCode MetadataSvc::finalize() { return Service::finalize(); }
 
-void MetadataSvc::setFrame(podio::Frame&& fr) { m_frame.reset(new podio::Frame(std::move(fr))); }
+void MetadataSvc::setFrame(podio::Frame&& fr) { m_frame = std::make_unique<podio::Frame>(std::move(fr)); }
 
 DECLARE_COMPONENT(MetadataSvc)

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -30,8 +30,6 @@ class MetadataSvc : public extends<Service, IMetadataSvc> {
   using extends::extends;
 
 public:
-  ~MetadataSvc() override = default;
-
   StatusCode initialize() override;
   StatusCode finalize() override;
 

--- a/k4FWCore/components/PodioOutput.h
+++ b/k4FWCore/components/PodioOutput.h
@@ -34,12 +34,12 @@ public:
   PodioOutput(const std::string& name, ISvcLocator* svcLoc);
 
   /// Initialization of PodioOutput. Acquires the data service, creates trees and root file.
-  StatusCode initialize();
+  StatusCode initialize() override;
   /// Execute. For the first event creates branches for all collections known to PodioDataSvc and prepares them for
   /// writing. For the following events it reconnects the branches with collections and prepares them for write.
-  StatusCode execute(const EventContext&) const;
+  StatusCode execute(const EventContext&) const override;
   /// Finalize. Writes the meta data tree; writes file and cleans up all ROOT-pointers.
-  StatusCode finalize();
+  StatusCode finalize() override;
 
 private:
   /// First event or not

--- a/k4FWCore/components/Reader.cpp
+++ b/k4FWCore/components/Reader.cpp
@@ -69,7 +69,7 @@ public:
                            Gaudi::Details::Property::ImmediatelyInvokeHandler{true}} {}
 
   // derived classes can NOT implement execute
-  StatusCode execute(const EventContext&) const override final {
+  StatusCode execute(const EventContext&) const final {
     try {
       auto out = (*this)();
 

--- a/k4FWCore/components/k4DataSvc.cpp
+++ b/k4FWCore/components/k4DataSvc.cpp
@@ -29,6 +29,3 @@ k4DataSvc::k4DataSvc(const std::string& name, ISvcLocator* svc) : PodioDataSvc(n
   declareProperty("input", m_filename = "", "Name of the file to read");
   declareProperty("FirstEventEntry", m_1stEvtEntry = 0, "First event to read");
 }
-
-/// Standard Destructor
-k4DataSvc::~k4DataSvc() {}

--- a/k4FWCore/components/k4DataSvc.h
+++ b/k4FWCore/components/k4DataSvc.h
@@ -26,8 +26,5 @@ class k4DataSvc : public PodioDataSvc {
 public:
   /// Standard Constructor
   k4DataSvc(const std::string& name, ISvcLocator* svc);
-
-  /// Standard Destructor
-  virtual ~k4DataSvc();
 };
 #endif

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -80,7 +80,7 @@ namespace k4FWCore {
           : Consumer(std::move(name), locator, inputs, std::index_sequence_for<In...>{}) {}
 
       // derived classes are NOT allowed to implement execute ...
-      StatusCode execute(const EventContext& ctx) const override final {
+      StatusCode execute(const EventContext& ctx) const final {
         try {
           filter_evtcontext_tt<In...>::apply(*this, ctx, m_inputs);
           return Gaudi::Functional::FilterDecision::PASSED;

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -183,9 +183,6 @@ namespace Gaudi {
   template <class T> class Property<::DataHandle<T>&> : public ::DataHandleProperty {
   public:
     Property(const std::string& name, ::DataHandle<T>& value) : ::DataHandleProperty(name, value) {}
-
-    /// virtual Destructor
-    virtual ~Property() {}
   };
 }  // namespace Gaudi
 

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -118,7 +118,7 @@ template <typename T> const T* DataHandle<T>::get() {
       // only do this once (if both are false after this, we throw exception)
       m_isGoodType = nullptr != dynamic_cast<DataWrapper<T>*>(dataObjectp);
       if (!m_isGoodType) {
-        auto tmp = dynamic_cast<DataWrapper<podio::CollectionBase>*>(dataObjectp);
+        auto* tmp = dynamic_cast<DataWrapper<podio::CollectionBase>*>(dataObjectp);
         if (tmp != nullptr) {
           m_isCollection = nullptr != dynamic_cast<T*>(tmp->collectionBase());
         }
@@ -129,7 +129,7 @@ template <typename T> const T* DataHandle<T>::get() {
     } else if (m_isCollection) {
       // The reader does not know the specific type of the collection. So we need a reinterpret_cast if the handle was
       // created by the reader.
-      DataWrapper<podio::CollectionBase>* tmp = static_cast<DataWrapper<podio::CollectionBase>*>(dataObjectp);
+      auto* tmp = static_cast<DataWrapper<podio::CollectionBase>*>(dataObjectp);
       return reinterpret_cast<const T*>(tmp->collectionBase());
     } else {
       // When a functional has pushed a std::shared_ptr<podio::CollectionBase> into the store

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -53,15 +53,15 @@ public:
   };
   virtual ~DataWrapper();
 
-  const T*     getData() const { return m_data; }
-  void         setData(const T* data) { m_data = data; }
-  virtual void resetData() { m_data = nullptr; }
+  const T* getData() const { return m_data; }
+  void     setData(const T* data) { m_data = data; }
+  void     resetData() override { m_data = nullptr; }
 
   operator const T&() const& { return *m_data; }
 
 private:
   /// try to cast to collectionBase; may return nullptr;
-  virtual podio::CollectionBase* collectionBase();
+  podio::CollectionBase* collectionBase() override;
 
 private:
   const T* m_data;

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -33,8 +33,7 @@ public:
   // ugly hack to circumvent the usage of boost::any yet
   // DataSvc would need a templated register method
   virtual podio::CollectionBase* collectionBase() = 0;
-  virtual ~DataWrapperBase(){};
-  virtual void resetData() = 0;
+  virtual void                   resetData()      = 0;
 };
 
 template <class T> class GAUDI_API DataWrapper : public DataWrapperBase {

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -19,6 +19,8 @@
 #ifndef FWCORE_IMETADATASERVICE_H
 #define FWCORE_IMETADATASERVICE_H
 
+#include <memory>
+
 #include "GaudiKernel/IInterface.h"
 
 #include "podio/Frame.h"
@@ -32,7 +34,7 @@ public:
   virtual void               setFrame(podio::Frame&& fr) = 0;
   template <typename T> void put(const std::string& name, const T& obj) {
     if (!m_frame) {
-      m_frame.reset(new podio::Frame());
+      m_frame = std::make_unique<podio::Frame>();
     }
     m_frame->putParameter(name, obj);
   }

--- a/k4FWCore/include/k4FWCore/KeepDropSwitch.h
+++ b/k4FWCore/include/k4FWCore/KeepDropSwitch.h
@@ -31,13 +31,13 @@ class KeepDropSwitch {
 public:
   enum Cmd { KEEP, DROP, UNKNOWN };
   typedef std::vector<std::string> CommandLines;
-  KeepDropSwitch() {}
+  KeepDropSwitch() = default;
   explicit KeepDropSwitch(const CommandLines& cmds) { m_commandlines = cmds; }
   bool isOn(const std::string& astring) const;
 
 private:
   bool                                getFlag(const std::string& astring) const;
-  Cmd                                 extractCommand(const std::string cmdLine) const;
+  Cmd                                 extractCommand(const std::string& cmdLine) const;
   CommandLines                        m_commandlines;
   mutable std::map<std::string, bool> m_cache;
 };

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -29,7 +29,6 @@ public:
   MetaDataHandle();
   MetaDataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode a);
   MetaDataHandle(const Gaudi::DataHandle& handle, const std::string& descriptor, Gaudi::DataHandle::Mode a);
-  ~MetaDataHandle();
 
   /// Get the value that is stored in this MetaDataHandle
   ///
@@ -68,8 +67,6 @@ private:
   const Gaudi::DataHandle*        m_dataHandle{nullptr};  // holds the identifier in case we do collection metadata
   Gaudi::DataHandle::Mode         m_mode;
 };
-
-template <typename T> MetaDataHandle<T>::~MetaDataHandle() {}
 
 //---------------------------------------------------------------------------
 template <typename T>

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -64,8 +64,7 @@ public:
   using DataSvc::registerObject;
   /// Overriding standard behaviour of evt service
   /// Register object with the data store.
-  virtual StatusCode registerObject(std::string_view parentPath, std::string_view fullPath,
-                                    DataObject* pObject) override final;
+  StatusCode registerObject(std::string_view parentPath, std::string_view fullPath, DataObject* pObject) final;
 
   const std::string_view getCollectionType(const std::string& collName);
 

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -57,9 +57,6 @@ public:
   /// Standard Constructor
   PodioDataSvc(const std::string& name, ISvcLocator* svc);
 
-  /// Standard Destructor
-  virtual ~PodioDataSvc();
-
   // Use DataSvc functionality except where we override
   using DataSvc::registerObject;
   /// Overriding standard behaviour of evt service

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -109,7 +109,7 @@ namespace k4FWCore {
                         std::index_sequence_for<Out>{}) {}
 
       // derived classes are NOT allowed to implement execute ...
-      StatusCode execute(const EventContext& ctx) const override final {
+      StatusCode execute(const EventContext& ctx) const final {
         try {
           if constexpr (isVectorLike<Out>::value) {
             std::tuple<Out> tmp = filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs);
@@ -245,7 +245,7 @@ namespace k4FWCore {
                              std::index_sequence_for<Out...>{}) {}
 
       // derived classes are NOT allowed to implement execute ...
-      StatusCode execute(const EventContext& ctx) const override final {
+      StatusCode execute(const EventContext& ctx) const final {
         try {
           auto tmp = filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs);
           putVectorOutputs<0, Out...>(std::move(tmp), m_outputs, this);

--- a/k4FWCore/src/KeepDropSwitch.cpp
+++ b/k4FWCore/src/KeepDropSwitch.cpp
@@ -58,7 +58,7 @@ std::vector<std::string> split(const std::string& s, char delim) {
   std::stringstream        ss(s);
   std::string              item;
   while (std::getline(ss, item, delim)) {
-    if (item != "")
+    if (!item.empty())
       elems.push_back(item);
   }
   return elems;
@@ -109,8 +109,8 @@ bool KeepDropSwitch::getFlag(const std::string& astring) const {
   return flag;
 }
 
-KeepDropSwitch::Cmd KeepDropSwitch::extractCommand(const std::string cmdline) const {
-  std::vector<std::string> words = split(cmdline, ' ');
+KeepDropSwitch::Cmd KeepDropSwitch::extractCommand(const std::string& cmdline) const {
+  auto words = split(cmdline, ' ');
   for (auto& word : words)
     std::cout << "'" << word << "' ";
   std::cout << std::endl;

--- a/k4FWCore/src/KeepDropSwitch.cpp
+++ b/k4FWCore/src/KeepDropSwitch.cpp
@@ -65,8 +65,7 @@ std::vector<std::string> split(const std::string& s, char delim) {
 }
 
 bool KeepDropSwitch::isOn(const std::string& astring) const {
-  typedef std::map<std::string, bool>::const_iterator MIter;
-  MIter                                               im = m_cache.find(astring);
+  auto im = m_cache.find(astring);
   if (im != m_cache.end())
     return im->second;
   else {

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -156,7 +156,7 @@ const std::string_view PodioDataSvc::getCollectionType(const std::string& collNa
 }
 
 StatusCode PodioDataSvc::registerObject(std::string_view parentPath, std::string_view fullPath, DataObject* pObject) {
-  DataWrapperBase* wrapper = dynamic_cast<DataWrapperBase*>(pObject);
+  auto* wrapper = dynamic_cast<DataWrapperBase*>(pObject);
   if (wrapper != nullptr) {
     podio::CollectionBase* coll = wrapper->collectionBase();
     if (coll != nullptr) {

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -143,9 +143,6 @@ void PodioDataSvc::endOfRead() {
 /// Standard Constructor
 PodioDataSvc::PodioDataSvc(const std::string& name, ISvcLocator* svc) : DataSvc(name, svc) {}
 
-/// Standard Destructor
-PodioDataSvc::~PodioDataSvc() {}
-
 const std::string_view PodioDataSvc::getCollectionType(const std::string& collName) {
   const auto coll = m_eventframe.get(collName);
   if (coll == nullptr) {

--- a/k4FWCore/src/PodioDataSvc.cpp
+++ b/k4FWCore/src/PodioDataSvc.cpp
@@ -35,12 +35,12 @@ StatusCode PodioDataSvc::initialize() {
   m_cnvSvc = svc_loc->service("EventPersistencySvc");
   status   = setDataLoader(m_cnvSvc);
 
-  if (m_filename != "") {
+  if (!m_filename.empty()) {
     m_filenames.push_back(m_filename);
   }
 
-  if (m_filenames.size() > 0) {
-    if (m_filenames[0] != "") {
+  if (!m_filenames.empty()) {
+    if (!m_filenames[0].empty()) {
       m_reading_from_file = true;
       m_reader.openFiles(m_filenames);
       m_numAvailableEvents = m_reader.getEntries("events");
@@ -84,7 +84,7 @@ StatusCode PodioDataSvc::reinitialize() {
 }
 /// Service finalization
 StatusCode PodioDataSvc::finalize() {
-  m_cnvSvc = 0;  // release
+  m_cnvSvc = nullptr;  // release
   DataSvc::finalize().ignore();
   return StatusCode::SUCCESS;
 }

--- a/k4Interface/include/k4Interface/IGeoSvc.h
+++ b/k4Interface/include/k4Interface/IGeoSvc.h
@@ -36,7 +36,6 @@ public:
   virtual dd4hep::Detector*            getDetector()                             = 0;
   virtual G4VUserDetectorConstruction* getGeant4Geo()                            = 0;
   virtual std::string                  constantAsString(std::string const& name) = 0;
-  virtual ~IGeoSvc() {}
 };
 
 #endif  // IGEOSVC_H

--- a/k4Interface/include/k4Interface/ITowerTool.h
+++ b/k4Interface/include/k4Interface/ITowerTool.h
@@ -85,8 +85,6 @@ public:
   virtual void attachCells(float aEta, float aPhi, uint aHalfEtaFinal, uint aHalfPhiFinal,
                            edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells,
                            bool aEllipse) = 0;
-
-  virtual ~ITowerTool() {}
 };
 
 #endif /* RECINTERFACE_ITOWERTOOL_H */

--- a/k4Interface/include/k4Interface/ITowerToolThetaModule.h
+++ b/k4Interface/include/k4Interface/ITowerToolThetaModule.h
@@ -85,8 +85,6 @@ public:
   virtual void attachCells(float aTheta, float aPhi, uint aHalfThetaFinal, uint aHalfPhiFinal,
                            edm4hep::MutableCluster& aEdmCluster, edm4hep::CalorimeterHitCollection* aEdmClusterCells,
                            bool aEllipse) = 0;
-
-  virtual ~ITowerToolThetaModule() {}
 };
 
 #endif /* RECINTERFACE_ITOWERTOOLTHETAMODULE_H */

--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -34,7 +34,7 @@ struct ExampleEventHeaderConsumer final : k4FWCore::Consumer<void(const edm4hep:
   ExampleEventHeaderConsumer(const std::string& name, ISvcLocator* svcLoc)
       : Consumer(name, svcLoc, {KeyValues("EventHeaderName", {edm4hep::labels::EventHeader})}) {}
 
-  void operator()(const edm4hep::EventHeaderCollection& evtHeaderColl) const {
+  void operator()(const edm4hep::EventHeaderCollection& evtHeaderColl) const override {
     if (evtHeaderColl.empty()) {
       throw std::runtime_error("EventHeader collection is empty");
     }

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
@@ -47,5 +47,3 @@ StatusCode TestUniqueIDGenSvc::execute(const EventContext&) const {
 
   return StatusCode::SUCCESS;
 }
-
-StatusCode TestUniqueIDGenSvc::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
@@ -23,8 +23,6 @@ DECLARE_COMPONENT(TestUniqueIDGenSvc)
 TestUniqueIDGenSvc::TestUniqueIDGenSvc(const std::string& aName, ISvcLocator* aSvcLoc)
     : Gaudi::Algorithm(aName, aSvcLoc) {}
 
-TestUniqueIDGenSvc::~TestUniqueIDGenSvc() {}
-
 StatusCode TestUniqueIDGenSvc::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
@@ -35,10 +35,6 @@ public:
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   SmartIF<IUniqueIDGenSvc> m_service;

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
@@ -31,15 +31,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   SmartIF<IUniqueIDGenSvc> m_service;

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.h
@@ -27,7 +27,6 @@
 class TestUniqueIDGenSvc : public Gaudi::Algorithm {
 public:
   explicit TestUniqueIDGenSvc(const std::string&, ISvcLocator*);
-  virtual ~TestUniqueIDGenSvc();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
@@ -32,8 +32,6 @@ k4FWCoreTest_AlgorithmWithTFile::k4FWCoreTest_AlgorithmWithTFile(const std::stri
   setProperty("Cardinality", 1).ignore();
 }
 
-k4FWCoreTest_AlgorithmWithTFile::~k4FWCoreTest_AlgorithmWithTFile() {}
-
 StatusCode k4FWCoreTest_AlgorithmWithTFile::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
@@ -48,15 +48,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   /// integer to add to the dummy values written to the edm

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
@@ -44,7 +44,6 @@ namespace edm4hep {
 class k4FWCoreTest_AlgorithmWithTFile : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_AlgorithmWithTFile(const std::string&, ISvcLocator*);
-  virtual ~k4FWCoreTest_AlgorithmWithTFile();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.cpp
@@ -32,8 +32,6 @@ k4FWCoreTest_CheckExampleEventData::k4FWCoreTest_CheckExampleEventData(const std
   setProperty("Cardinality", 1).ignore();
 }
 
-StatusCode k4FWCoreTest_CheckExampleEventData::initialize() { return Gaudi::Algorithm::initialize(); }
-
 StatusCode k4FWCoreTest_CheckExampleEventData::execute(const EventContext&) const {
   auto floatVector = m_vectorFloatHandle.get();
   if (floatVector->size() != 3 || (*floatVector)[2] != m_event) {
@@ -59,5 +57,3 @@ StatusCode k4FWCoreTest_CheckExampleEventData::execute(const EventContext&) cons
   }
   return StatusCode::SUCCESS;
 }
-
-StatusCode k4FWCoreTest_CheckExampleEventData::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -38,15 +38,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   /// integer to add to the dummy values written to the edm

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -35,18 +35,10 @@ class k4FWCoreTest_CheckExampleEventData : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_CheckExampleEventData(const std::string&, ISvcLocator*);
   ~k4FWCoreTest_CheckExampleEventData() = default;
-  /**  Initialize.
-   *   @return status code
-   */
-  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   /// integer to add to the dummy values written to the edm

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -46,8 +46,6 @@ k4FWCoreTest_CreateExampleEventData::k4FWCoreTest_CreateExampleEventData(const s
   setProperty("Cardinality", 1).ignore();
 }
 
-k4FWCoreTest_CreateExampleEventData::~k4FWCoreTest_CreateExampleEventData() {}
-
 StatusCode k4FWCoreTest_CreateExampleEventData::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.cpp
@@ -46,13 +46,6 @@ k4FWCoreTest_CreateExampleEventData::k4FWCoreTest_CreateExampleEventData(const s
   setProperty("Cardinality", 1).ignore();
 }
 
-StatusCode k4FWCoreTest_CreateExampleEventData::initialize() {
-  if (Gaudi::Algorithm::initialize().isFailure()) {
-    return StatusCode::FAILURE;
-  }
-  return StatusCode::SUCCESS;
-}
-
 StatusCode k4FWCoreTest_CreateExampleEventData::execute(const EventContext&) const {
   auto* floatVector = m_vectorFloatHandle.createAndPut();
   floatVector->push_back(125.);
@@ -104,5 +97,3 @@ StatusCode k4FWCoreTest_CreateExampleEventData::execute(const EventContext&) con
 
   return StatusCode::SUCCESS;
 }
-
-StatusCode k4FWCoreTest_CreateExampleEventData::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -60,15 +60,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   /// integer to add to the dummy values written to the edm

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -56,7 +56,6 @@ namespace edm4hep {
 class k4FWCoreTest_CreateExampleEventData : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_CreateExampleEventData(const std::string&, ISvcLocator*);
-  virtual ~k4FWCoreTest_CreateExampleEventData();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -56,18 +56,10 @@ namespace edm4hep {
 class k4FWCoreTest_CreateExampleEventData : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_CreateExampleEventData(const std::string&, ISvcLocator*);
-  /**  Initialize.
-   *   @return status code
-   */
-  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   /// integer to add to the dummy values written to the edm

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.cpp
@@ -27,13 +27,6 @@ k4FWCoreTest_HelloWorldAlg::k4FWCoreTest_HelloWorldAlg(const std::string& aName,
   setProperty("Cardinality", 1).ignore();
 }
 
-StatusCode k4FWCoreTest_HelloWorldAlg::initialize() {
-  if (Gaudi::Algorithm::initialize().isFailure()) {
-    return StatusCode::FAILURE;
-  }
-  return StatusCode::SUCCESS;
-}
-
 StatusCode k4FWCoreTest_HelloWorldAlg::execute(const EventContext&) const {
   info() << endmsg;
   info() << endmsg;
@@ -42,5 +35,3 @@ StatusCode k4FWCoreTest_HelloWorldAlg::execute(const EventContext&) const {
   info() << endmsg;
   return StatusCode::SUCCESS;
 }
-
-StatusCode k4FWCoreTest_HelloWorldAlg::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.cpp
@@ -27,8 +27,6 @@ k4FWCoreTest_HelloWorldAlg::k4FWCoreTest_HelloWorldAlg(const std::string& aName,
   setProperty("Cardinality", 1).ignore();
 }
 
-k4FWCoreTest_HelloWorldAlg::~k4FWCoreTest_HelloWorldAlg() {}
-
 StatusCode k4FWCoreTest_HelloWorldAlg::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
@@ -26,18 +26,10 @@
 class k4FWCoreTest_HelloWorldAlg : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_HelloWorldAlg(const std::string&, ISvcLocator*);
-  /**  Initialize.
-   *   @return status code
-   */
-  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   // member variable

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
@@ -30,15 +30,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   // member variable

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_HelloWorldAlg.h
@@ -26,7 +26,6 @@
 class k4FWCoreTest_HelloWorldAlg : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_HelloWorldAlg(const std::string&, ISvcLocator*);
-  virtual ~k4FWCoreTest_HelloWorldAlg();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -29,13 +29,6 @@ k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName,
   setProperty("Cardinality", 1).ignore();
 }
 
-StatusCode k4FWCoreTest_cellID_reader::initialize() {
-  if (Gaudi::Algorithm::initialize().isFailure()) {
-    return StatusCode::FAILURE;
-  }
-  return StatusCode::SUCCESS;
-}
-
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   [[maybe_unused]] const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
@@ -48,5 +41,3 @@ StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
 
   return StatusCode::SUCCESS;
 }
-
-StatusCode k4FWCoreTest_cellID_reader::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -29,8 +29,6 @@ k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName,
   setProperty("Cardinality", 1).ignore();
 }
 
-k4FWCoreTest_cellID_reader::~k4FWCoreTest_cellID_reader() {}
-
 StatusCode k4FWCoreTest_cellID_reader::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -40,15 +40,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   /// Handle for the SimTrackerHits to be read

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -36,18 +36,10 @@
 class k4FWCoreTest_cellID_reader : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_cellID_reader(const std::string&, ISvcLocator*);
-  /**  Initialize.
-   *   @return status code
-   */
-  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   /// Handle for the SimTrackerHits to be read

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -36,7 +36,6 @@
 class k4FWCoreTest_cellID_reader : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_cellID_reader(const std::string&, ISvcLocator*);
-  virtual ~k4FWCoreTest_cellID_reader();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
@@ -44,5 +44,3 @@ StatusCode k4FWCoreTest_cellID_writer::execute(const EventContext&) const {
 
   return StatusCode::SUCCESS;
 }
-
-StatusCode k4FWCoreTest_cellID_writer::finalize() { return Gaudi::Algorithm::finalize(); }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
@@ -28,8 +28,6 @@ k4FWCoreTest_cellID_writer::k4FWCoreTest_cellID_writer(const std::string& aName,
   setProperty("Cardinality", 1).ignore();
 }
 
-k4FWCoreTest_cellID_writer::~k4FWCoreTest_cellID_writer() {}
-
 StatusCode k4FWCoreTest_cellID_writer::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -39,7 +39,6 @@ const std::string cellIDtest = "M:3,S-1:3,I:9,J:9,K-1:6";
 class k4FWCoreTest_cellID_writer : public Gaudi::Algorithm {
 public:
   explicit k4FWCoreTest_cellID_writer(const std::string&, ISvcLocator*);
-  virtual ~k4FWCoreTest_cellID_writer();
   /**  Initialize.
    *   @return status code
    */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -47,10 +47,6 @@ public:
    *   @return status code
    */
   StatusCode execute(const EventContext&) const final;
-  /**  Finalize.
-   *   @return status code
-   */
-  StatusCode finalize() final;
 
 private:
   /// Handle for the SimTrackerHits to be written

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -43,15 +43,15 @@ public:
   /**  Initialize.
    *   @return status code
    */
-  virtual StatusCode initialize() final;
+  StatusCode initialize() final;
   /**  Execute.
    *   @return status code
    */
-  virtual StatusCode execute(const EventContext&) const final;
+  StatusCode execute(const EventContext&) const final;
   /**  Finalize.
    *   @return status code
    */
-  virtual StatusCode finalize() final;
+  StatusCode finalize() final;
 
 private:
   /// Handle for the SimTrackerHits to be written


### PR DESCRIPTION
BEGINRELEASENOTES
- fixed virtual specifiers, removed redundant methods, uncluttered code

ENDRELEASENOTES

This is an attempt to slightly reduce the amount of dated and obsolete code:
 - missing or redundant virtual, override, final specifiers
 -  redundant declarations of trivial virtual destruction when base method already has virtual destructor,
 - removed redundant empty destructors
 - use `empty()` methods instead of comparison for `vector` and `string`
 - use make smart pointer instead of `reset(new `
 - use auto instead of repeating a type or type long iterator types