### PR TITLE
Fix accessing metadata with `MetaDataHandle` when `MetadataSvc` is present

### DIFF
--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -89,8 +89,10 @@ MetaDataHandle<T>::MetaDataHandle(const Gaudi::DataHandle& handle, const std::st
 
 //---------------------------------------------------------------------------
 template <typename T> std::optional<T> MetaDataHandle<T>::get_optional() const {
-  const auto& frame = m_podio_data_service->getMetaDataFrame();
-  return frame.getParameter<T>(fullDescriptor());
+  if (m_podio_data_service) {
+    return m_podio_data_service->getMetaDataFrame().getParameter<T>(fullDescriptor());
+  }
+  return k4FWCore::getParameter<T>(fullDescriptor());
 }
 
 //---------------------------------------------------------------------------

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -97,19 +97,12 @@ template <typename T> std::optional<T> MetaDataHandle<T>::get_optional() const {
 
 //---------------------------------------------------------------------------
 template <typename T> const T MetaDataHandle<T>::get() const {
-  std::optional<T> maybeVal;
-  // DataHandle based algorithms
-  if (m_podio_data_service) {
-    maybeVal = get_optional();
-    if (!maybeVal.has_value()) {
-      throw GaudiException("MetaDataHandle empty handle access",
-                           "MetaDataHandle " + fullDescriptor() + " not (yet?) available", StatusCode::FAILURE);
-    }
-    // Functional algorithms
-  } else {
-    maybeVal = k4FWCore::getParameter<T>(fullDescriptor());
+  auto optional_parameter = get_optional();
+  if (!optional_parameter.has_value()) {
+    throw GaudiException("MetaDataHandle empty handle access",
+                         "MetaDataHandle " + fullDescriptor() + " not (yet?) available", StatusCode::FAILURE);
   }
-  return maybeVal.value();
+  return optional_parameter.value();
 }
 
 //---------------------------------------------------------------------------

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -159,12 +159,8 @@ template <typename T> void MetaDataHandle<T>::checkPodioDataSvc() {
   if (cmd.find("genconf") != std::string::npos)
     return;
 
-  // The proper check would be the following:
-  // if (!m_podio_data_service && !Gaudi::svcLocator()->service<IMetadataSvc>("MetadataSvc")) {
-  // However, it seems there is always a service called "MetadataSvc" from Gaudi,
-  // so the check will always pass
-  if (!m_podio_data_service) {
-    std::cout << "Warning: MetaDataHandles require the PodioDataSvc (ignore if using IOSvc)" << std::endl;
+  if (!m_podio_data_service && !Gaudi::svcLocator()->service<IMetadataSvc>("MetadataSvc", false)) {
+    std::cout << "Warning: MetaDataHandles require the PodioDataSvc or for compatibility the MetadataSvc" << std::endl;
   }
 }
 

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -26,7 +26,6 @@
 
 template <typename T> class MetaDataHandle {
 public:
-  MetaDataHandle();
   MetaDataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode a);
   MetaDataHandle(const Gaudi::DataHandle& handle, const std::string& descriptor, Gaudi::DataHandle::Mode a);
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -42,12 +42,12 @@ StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   auto optCellIDstr = m_cellIDHandle.get_optional();
 
   if (!optCellIDstr.has_value()) {
-    error() << "ERROR cellID is empty but was expected to hold a value" << endmsg;
+    error() << "ERROR: cellID is empty but was expected to hold a value" << endmsg;
     return StatusCode::FAILURE;
   }
 
   if (optCellIDstr.value() != cellIDstr) {
-    error() << "ERROR metadata accessed with by optional and value differs" << endmsg;
+    error() << "ERROR: metadata accessed with by optional and value differs" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -39,5 +39,17 @@ StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
     return StatusCode::FAILURE;
   }
 
+  auto optCellIDstr = m_cellIDHandle.get_optional();
+
+  if (!optCellIDstr.has_value()) {
+    error() << "ERROR cellID is empty but was expected to hold a value" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  if (optCellIDstr.value() != cellIDstr) {
+    error() << "ERROR metadata accessed with by optional and value differs" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
   return StatusCode::SUCCESS;
 }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fixed missing checks for accessing metadata with `MetaDataHandle` when used with `IOSvc`

ENDRELEASENOTES

Fixes for `MetaDataHandle` interoperability with `PodioDataSvc` and new `MetadataSvc`/`IOSvc` introduced in #215:
- `MetaDataHandle::get_optional` wasn't checking whether `PodioDataSvc` or `IOSvc` is used
- `MetaDataHandle::get` didn't check validity of optional when used with `IOSvc`

And some additional cleanup:
- removed constructor with missing definition (unused otherwise that would be an error)
- removed workaround for checking service existence. Gaudi's `service` by default initializes a service if it's missing, hence the check was always true

---

This is PR is orthogonal and doesn't depend on #223 