### PR TITLE
Use podio::Reader and podio::Writer with IOSvc

### DIFF
--- a/k4FWCore/CMakeLists.txt
+++ b/k4FWCore/CMakeLists.txt
@@ -31,7 +31,7 @@ gaudi_install(PYTHON)
 gaudi_add_library(k4FWCore
 		  SOURCES src/PodioDataSvc.cpp
               src/KeepDropSwitch.cpp
-                  LINK Gaudi::GaudiKernel podio::podioRootIO ROOT::Core ROOT::RIO ROOT::Tree
+                  LINK Gaudi::GaudiKernel podio::podioIO ROOT::Core ROOT::RIO ROOT::Tree
                   )
 target_include_directories(k4FWCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>

--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -22,7 +22,7 @@
 #include "GaudiKernel/IInterface.h"
 
 #include "podio/CollectionBase.h"
-#include "podio/ROOTWriter.h"
+#include "podio/Writer.h"
 
 #include <memory>
 #include <vector>
@@ -48,10 +48,10 @@ public:
                                                     next()                     = 0;
   virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
 
-  virtual std::shared_ptr<podio::ROOTWriter> getWriter()                                         = 0;
-  virtual void                               deleteWriter()                                      = 0;
-  virtual void                               deleteReader()                                      = 0;
-  virtual bool                               checkIfWriteCollection(const std::string& collName) = 0;
+  virtual std::shared_ptr<podio::Writer> getWriter()                                         = 0;
+  virtual void                           deleteWriter()                                      = 0;
+  virtual void                           deleteReader()                                      = 0;
+  virtual bool                           checkIfWriteCollection(const std::string& collName) = 0;
 };
 
 #endif

--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -43,10 +43,10 @@ public:
                                                     next()                     = 0;
   virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
 
-  virtual podio::Writer&                 getWriter()                                         = 0;
-  virtual void                           deleteWriter()                                      = 0;
-  virtual void                           deleteReader()                                      = 0;
-  virtual bool                           checkIfWriteCollection(const std::string& collName) = 0;
+  virtual podio::Writer& getWriter()                                         = 0;
+  virtual void           deleteWriter()                                      = 0;
+  virtual void           deleteReader()                                      = 0;
+  virtual bool           checkIfWriteCollection(const std::string& collName) = 0;
 };
 
 #endif

--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -32,11 +32,6 @@
  */
 class IIOSvc : virtual public IInterface {
 public:
-  struct EndOfInput : std::logic_error {
-    EndOfInput() : logic_error("Reached end of input while more data were expected"){};
-  };
-
-public:
   /// InterfaceID
   DeclareInterfaceID(IIOSvc, 1, 0);
 
@@ -48,7 +43,7 @@ public:
                                                     next()                     = 0;
   virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
 
-  virtual std::shared_ptr<podio::Writer> getWriter()                                         = 0;
+  virtual podio::Writer&                 getWriter()                                         = 0;
   virtual void                           deleteWriter()                                      = 0;
   virtual void                           deleteReader()                                      = 0;
   virtual bool                           checkIfWriteCollection(const std::string& collName) = 0;

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -44,7 +44,7 @@ StatusCode IOSvc::initialize() {
             << endmsg;
   }
   if (m_outputType != "default" && m_outputType != "ROOT" && m_outputType != "RNTuple") {
-    error() << "Unknown input type: " << m_outputType << ", expected ROOT or RNTuple" << endmsg;
+    error() << "Unknown input type: " << m_outputType << ", expected ROOT, RNTuple or default" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -43,8 +43,8 @@ StatusCode IOSvc::initialize() {
     error() << "Use 'from k4FWCore import IOSvc' instead of 'from Configurables import IOSvc' to access the service"
             << endmsg;
   }
-  if (m_inputType != "ROOT" && m_inputType != "RNTuple") {
-    error() << "Unknown input type: " << m_inputType << ", expected ROOT or RNTuple" << endmsg;
+  if (m_outputType != "default" && m_outputType != "ROOT" && m_outputType != "RNTuple") {
+    error() << "Unknown input type: " << m_outputType << ", expected ROOT or RNTuple" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -54,7 +54,7 @@ StatusCode IOSvc::initialize() {
   }
   if (!m_readingFileNames.empty()) {
     try {
-      m_reader = std::make_unique<podio::Reader>(podio::makeReader(m_readingFileNames.value()));
+      m_reader = podio::makeReader(m_readingFileNames.value());
     } catch (std::runtime_error& e) {
       error() << "Error when opening files: " << e.what() << endmsg;
       return StatusCode::FAILURE;

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -61,7 +61,6 @@ StatusCode IOSvc::initialize() {
     }
     m_entries = m_reader->getEvents();
   }
-  }
 
   if ((m_entries && m_firstEventEntry >= m_entries) || m_firstEventEntry < 0) {
     error() << "First event entry is larger than the number of entries in the file or negative" << endmsg;

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -26,8 +26,8 @@
 #include "GaudiKernel/IIncidentSvc.h"
 #include "GaudiKernel/Service.h"
 
-#include "podio/ROOTReader.h"
-#include "podio/ROOTWriter.h"
+#include "podio/Reader.h"
+#include "podio/Writer.h"
 
 #include "IIOSvc.h"
 #include "k4FWCore/IMetadataSvc.h"
@@ -73,12 +73,12 @@ protected:
 
   KeepDropSwitch m_switch;
 
-  std::unique_ptr<podio::ROOTReader> m_reader{nullptr};
-  std::shared_ptr<podio::ROOTWriter> m_writer{nullptr};
+  std::unique_ptr<podio::Reader> m_reader{nullptr};
+  std::shared_ptr<podio::Writer> m_writer{nullptr};
 
-  std::shared_ptr<podio::ROOTWriter> getWriter() override {
+  std::shared_ptr<podio::Writer> getWriter() override {
     if (!m_writer) {
-      m_writer = std::make_shared<podio::ROOTWriter>(m_writingFileName.value());
+      m_writer = std::make_shared<podio::Writer>(podio::makeWriter(m_writingFileName.value(), m_inputType));
     }
     return m_writer;
   }

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -62,7 +62,7 @@ protected:
   Gaudi::Property<std::string> m_writingFileName{this, "Output", {}, "List of files to write output to"};
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};
-  Gaudi::Property<std::string> m_inputType{this, "IOType", "ROOT", "Type of input file (ROOT, RNTuple)"};
+  Gaudi::Property<std::string> m_outputType{this, "OutputType", "default", "Type of the output file (ROOT or RNTuple, or default)"};
 
   Gaudi::Property<bool> m_importedFromk4FWCore{
       this, "ImportedFromk4FWCore", false,
@@ -78,7 +78,7 @@ protected:
 
   std::shared_ptr<podio::Writer> getWriter() override {
     if (!m_writer) {
-      m_writer = std::make_shared<podio::Writer>(podio::makeWriter(m_writingFileName.value(), m_inputType));
+      m_writer = std::make_shared<podio::Writer>(podio::makeWriter(m_writingFileName.value(), m_outputType));
     }
     return m_writer;
   }

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -62,7 +62,8 @@ protected:
   Gaudi::Property<std::string> m_writingFileName{this, "Output", {}, "List of files to write output to"};
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};
-  Gaudi::Property<std::string> m_outputType{this, "OutputType", "default", "Type of the output file (ROOT or RNTuple, or default)"};
+  Gaudi::Property<std::string> m_outputType{this, "OutputType", "default",
+                                            "Type of the output file (ROOT or RNTuple, or default)"};
 
   Gaudi::Property<bool> m_importedFromk4FWCore{
       this, "ImportedFromk4FWCore", false,

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -74,14 +74,14 @@ protected:
 
   KeepDropSwitch m_switch;
 
-  std::unique_ptr<podio::Reader> m_reader{nullptr};
-  std::shared_ptr<podio::Writer> m_writer{nullptr};
+  std::optional<podio::Reader> m_reader;
+  std::optional<podio::Writer> m_writer;
 
-  std::shared_ptr<podio::Writer> getWriter() override {
+  podio::Writer& getWriter() override {
     if (!m_writer) {
-      m_writer = std::make_shared<podio::Writer>(podio::makeWriter(m_writingFileName.value(), m_outputType));
+      m_writer = podio::makeWriter(m_writingFileName.value(), m_outputType);
     }
-    return m_writer;
+    return *m_writer;
   }
 
   // Gaudi doesn't always run the destructor of the Services so we have to

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -120,10 +120,10 @@ public:
     if (const char* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
       config_metadata_frame.putParameter("key4hepstack", env_key4hep_stack);
     }
-    iosvc->getWriter()->writeFrame(config_metadata_frame, "configuration_metadata");
+    iosvc->getWriter().writeFrame(config_metadata_frame, "configuration_metadata");
 
     if (const auto* metadata_frame = m_metadataSvc->getFrame(); metadata_frame) {
-      iosvc->getWriter()->writeFrame(*metadata_frame, podio::Category::Metadata);
+      iosvc->getWriter().writeFrame(*metadata_frame, podio::Category::Metadata);
     }
 
     iosvc->deleteWriter();
@@ -262,7 +262,7 @@ public:
     }
 
     debug() << "Writing frame" << endmsg;
-    iosvc->getWriter()->writeFrame(ptr->getData(), podio::Category::Event, m_collectionsToSave);
+    iosvc->getWriter().writeFrame(ptr->getData(), podio::Category::Event, m_collectionsToSave);
   }
 };
 

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -173,6 +173,7 @@ add_test_with_env(FunctionalWrongImport options/ExampleFunctionalWrongImport.py)
 set_tests_properties(FunctionalWrongImport PROPERTIES PASS_REGULAR_EXPRESSION "ImportError: Importing ApplicationMgr or IOSvc from Configurables is not allowed.")
 add_test_with_env(FunctionalReadNthEvent options/ExampleFunctionalReadNthEvent.py ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalProducerRNTuple options/ExampleFunctionalProducerRNTuple.py ADD_TO_CHECK_FILES)
+add_test_with_env(FunctionalTTreeToRNTuple options/ExampleFunctionalTTreeToRNTuple.py ADD_TO_CHECK_FILES)
 
 # Do this after checking the files not to overwrite them
 add_test_with_env(FunctionalFile_toolong options/ExampleFunctionalFile.py -n 999 PROPERTIES DEPENDS FunctionalCheckFiles PASS_REGULAR_EXPRESSION

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -21,7 +21,7 @@ file(GLOB k4fwcoretest_plugin_sources src/components/*.cpp)
 
 gaudi_add_module(k4FWCoreTestPlugins
                  SOURCES ${k4fwcoretest_plugin_sources}
-                 LINK Gaudi::GaudiKernel k4FWCore k4FWCore::k4Interface ROOT::Core ROOT::RIO ROOT::Tree EDM4HEP::edm4hepDict EDM4HEP::edm4hep)
+                 LINK Gaudi::GaudiKernel k4FWCore k4FWCore::k4Interface ROOT::Core ROOT::RIO ROOT::Tree podio::podioIO EDM4HEP::edm4hep)
 
 include(CTest)
 
@@ -172,6 +172,7 @@ add_test_with_env(FunctionalMetadataReadOldAlgorithm options/ExampleFunctionalMe
 add_test_with_env(FunctionalWrongImport options/ExampleFunctionalWrongImport.py)
 set_tests_properties(FunctionalWrongImport PROPERTIES PASS_REGULAR_EXPRESSION "ImportError: Importing ApplicationMgr or IOSvc from Configurables is not allowed.")
 add_test_with_env(FunctionalReadNthEvent options/ExampleFunctionalReadNthEvent.py ADD_TO_CHECK_FILES)
+add_test_with_env(FunctionalProducerRNTuple options/ExampleFunctionalProducerRNTuple.py ADD_TO_CHECK_FILES)
 
 # Do this after checking the files not to overwrite them
 add_test_with_env(FunctionalFile_toolong options/ExampleFunctionalFile.py -n 999 PROPERTIES DEPENDS FunctionalCheckFiles PASS_REGULAR_EXPRESSION

--- a/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
@@ -26,7 +26,7 @@ from k4FWCore import ApplicationMgr, IOSvc
 
 iosvc = IOSvc("IOSvc")
 iosvc.Output = "functional_producer_rntuple.root"
-iosvc.IOType = "RNTuple"
+iosvc.OutputType = "RNTuple"
 
 
 producer = ExampleFunctionalProducer("ExampleFunctionalProducer")

--- a/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
@@ -27,8 +27,6 @@ from k4FWCore import ApplicationMgr, IOSvc
 iosvc = IOSvc("IOSvc")
 iosvc.Output = "functional_producer_rntuple.root"
 iosvc.IOType = "RNTuple"
-# Collections can be dropped
-# out.outputCommands = ["drop *"]
 
 
 producer = ExampleFunctionalProducer("ExampleFunctionalProducer")

--- a/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an example using a producer with a single output and saving that to an RNTuple file
+
+from Gaudi.Configuration import INFO
+from Configurables import ExampleFunctionalProducer
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
+
+iosvc = IOSvc("IOSvc")
+name = "functional_producer_rntuple.root"
+iosvc.Output = name
+iosvc.IOType = "RNTuple"
+# Collections can be dropped
+# out.outputCommands = ["drop *"]
+
+
+producer = ExampleFunctionalProducer("ExampleFunctionalProducer")
+
+ApplicationMgr(
+    TopAlg=[producer],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalProducerRNTuple.py
@@ -25,8 +25,7 @@ from Configurables import EventDataSvc
 from k4FWCore import ApplicationMgr, IOSvc
 
 iosvc = IOSvc("IOSvc")
-name = "functional_producer_rntuple.root"
-iosvc.Output = name
+iosvc.Output = "functional_producer_rntuple.root"
 iosvc.IOType = "RNTuple"
 # Collections can be dropped
 # out.outputCommands = ["drop *"]

--- a/test/k4FWCoreTest/options/ExampleFunctionalTTreeToRNTuple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalTTreeToRNTuple.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an example algorithm to modify a TTree into an RNTuple
+# Don't use! There is already a converter in podio called
+# podio-ttree-to-rntuple
+# Running with k4run will add some extra configuration metadata to the file
+
+from Gaudi.Configuration import INFO
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
+
+iosvc = IOSvc("IOSvc")
+iosvc.Input = "functional_producer.root"
+iosvc.Output = "functional_producer_rntuple_converted.root"
+iosvc.OutputType = "RNTuple"
+
+ApplicationMgr(
+    TopAlg=[],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/options/ExampleFunctionalWrongImport.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalWrongImport.py
@@ -17,8 +17,7 @@
 # limitations under the License.
 #
 
-# This is an example reading from a file and using a transformer to create new
-# data
+# This is an example of imports that should fail with the checks from utils.py
 
 
 # fmt: off

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -183,6 +183,27 @@ check_metadata(
     },
 )
 
+reader = podio.root_io.Reader("functional_metadata.root")
+metadata = reader.get("metadata")[0]
+for key, value in zip(
+    [
+        "NumberOfParticles",
+        "ParticleTime",
+        "PDGValues",
+        "MetadataString",
+        "FinalizeMetadataInt",
+    ],
+    [3, 1.5, [1, 2, 3, 4], "hello", 10],
+):
+    if metadata.get_parameter(key) != value:
+        raise RuntimeError(
+            f"Metadata parameter {key} does not match the expected value, got {metadata.get_parameter(key)} but expected {value}"
+        )
+podio_reader = podio.root_io.RNTupleReader("functional_producer_rntuple.root")
+frames = podio_reader.get("events")
+if len(frames) != 10:
+    raise RuntimeError(f"Expected 10 events but got {len(frames)}")
+
 check_metadata(
     "functional_metadata_propagate.root",
     {

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -199,10 +199,11 @@ for key, value in zip(
         raise RuntimeError(
             f"Metadata parameter {key} does not match the expected value, got {metadata.get_parameter(key)} but expected {value}"
         )
-podio_reader = podio.root_io.RNTupleReader("functional_producer_rntuple.root")
-frames = podio_reader.get("events")
-if len(frames) != 10:
-    raise RuntimeError(f"Expected 10 events but got {len(frames)}")
+for rntuple in ["functional_producer_rntuple.root", "functional_producer_rntuple_converted.root"]:
+    reader = podio.root_io.RNTupleReader(f"{rntuple}")
+    frames = podio_reader.get("events")
+    if len(frames) != 10:
+        raise RuntimeError(f"Expected 10 events but got {len(frames)}")
 
 check_metadata(
     "functional_metadata_propagate.root",


### PR DESCRIPTION
BEGINRELEASENOTES
- Use podio::Reader and podio::Writer with IOSvc, so that it is easy to write TTrees or RNTuples by changing the `IOType` parameter given to `IOSvc` in the steering file.

ENDRELEASENOTES