### PR TITLE
Assign to a const char* when using std::getenv

### DIFF
--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -140,7 +140,7 @@ StatusCode PodioOutput::finalize() {
   // Collect all the metadata
   podio::Frame config_metadata_frame{};
   config_metadata_frame.putParameter("gaudiConfigOptions", config_data);
-  if (const auto* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
+  if (const char* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
     std::string s_env_key4hep_stack = env_key4hep_stack;
     config_metadata_frame.putParameter("key4hepstack", s_env_key4hep_stack);
   }

--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -140,7 +140,7 @@ StatusCode PodioOutput::finalize() {
   // Collect all the metadata
   podio::Frame config_metadata_frame{};
   config_metadata_frame.putParameter("gaudiConfigOptions", config_data);
-  if (const char* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
+  if (const auto* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
     std::string s_env_key4hep_stack = env_key4hep_stack;
     config_metadata_frame.putParameter("key4hepstack", s_env_key4hep_stack);
   }

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -117,7 +117,7 @@ public:
     }
 
     config_metadata_frame.putParameter("gaudiConfigOptions", config_data);
-    if (auto env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
+    if (const auto* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
       config_metadata_frame.putParameter("key4hepstack", env_key4hep_stack);
     }
     iosvc->getWriter()->writeFrame(config_metadata_frame, "configuration_metadata");

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -117,7 +117,7 @@ public:
     }
 
     config_metadata_frame.putParameter("gaudiConfigOptions", config_data);
-    if (const auto* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
+    if (const char* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {
       config_metadata_frame.putParameter("key4hepstack", env_key4hep_stack);
     }
     iosvc->getWriter()->writeFrame(config_metadata_frame, "configuration_metadata");


### PR DESCRIPTION
BEGINRELEASENOTES
- Assign to a const char* when using std::getenv

ENDRELEASENOTES

Discovered after https://github.com/AIDASoft/podio/pull/676, it turns out that the one in Writer.cpp was not being assigned to `const char*` and it failed (it doesn't fail anymore after https://github.com/AIDASoft/podio/pull/680). Because `const auto` translates to `char* const` while `const auto*` translates to `const char*`. Use `*`!