### PR TITLE
Fix histograms for Gaudi v39 and add a configurable histogram

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -60,11 +60,9 @@ def add_arguments(parser, app_mgr):
         # skip public tools and the applicationmgr itself
         if "ToolSvc" in conf.name() or "ApplicationMgr" in conf.name():
             continue
-        props = (
-            conf.getPropertiesWithDescription()
-        )  # dict propertyname: (propertyvalue, propertydescription)
+        # dict propertyname: (propertyvalue, propertydescription)
+        props = conf.getPropertiesWithDescription()
         for prop in props:
-            # only add arguments for relevant properties
             if (
                 prop in FILTER_GAUDI_PROPS
                 or "Audit" in prop
@@ -208,7 +206,12 @@ def main():
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
         logger.info("Option name: %s %s %s", propTuple[1], optionName, opts_dict[optionName])
-        propTuple[0].setProp(propTuple[1].rsplit(".", 1)[1], opts_dict[optionName])
+        if "_Axis" in optionName:
+            propTuple[0].setProp(
+                propTuple[1].rsplit(".", 1)[1], tuple(x for x in opts_dict[optionName] if x != ())
+            )
+        else:
+            propTuple[0].setProp(propTuple[1].rsplit(".", 1)[1], opts_dict[optionName])
 
     if opts.verbose:
         from Gaudi.Configuration import VERBOSE

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -206,6 +206,9 @@ def main():
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
         logger.info("Option name: %s %s %s", propTuple[1], optionName, opts_dict[optionName])
+        # After Gaudi v40 the new configurable histograms have properties that are tuples
+        # and by default one of the member is an empty tuple that Gaudi seems not to like
+        # when used in setProp - it will try to parse it as a string and fail
         if "_Axis" in optionName:
             propTuple[0].setProp(
                 propTuple[1].rsplit(".", 1)[1], tuple(x for x in opts_dict[optionName] if x != ())

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -206,7 +206,7 @@ def main():
     opts_dict = vars(opts)
     for optionName, propTuple in option_db.items():
         logger.info("Option name: %s %s %s", propTuple[1], optionName, opts_dict[optionName])
-        # After Gaudi v40 the new configurable histograms have properties that are tuples
+        # After Gaudi v39 the new configurable histograms have properties that are tuples
         # and by default one of the member is an empty tuple that Gaudi seems not to like
         # when used in setProp - it will try to parse it as a string and fail
         if "_Axis" in optionName:

--- a/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
@@ -73,6 +73,14 @@ hps = RootHistSvc("HistogramPersistencySvc")
 root_hist_svc = RootHistoSink("RootHistoSink")
 root_hist_svc.FileName = "functional_transformer_hist.root"
 
+try:
+    transformer1.CustomHistogram_Title = "Custom Title"
+    # Bins can be defined here
+    transformer1.CustomHistogram_Axis0 = (10, -5.0, 10.0, "X")
+# Before Gaudi v40 there isn't a way to set the bins from python
+except Exception:
+    pass
+
 
 app = ApplicationMgr(
     TopAlg=[producer1, producer2, transformer1, transformer2],

--- a/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
@@ -77,7 +77,7 @@ try:
     transformer1.CustomHistogram_Title = "Custom Title"
     # Bins can be defined here
     transformer1.CustomHistogram_Axis0 = (10, -5.0, 10.0, "X")
-# Before Gaudi v40 there isn't a way to set the bins from python
+# Before Gaudi v39 there isn't a way to set the bins from python
 except Exception:
     pass
 

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
@@ -25,8 +25,22 @@
 
 #include <string>
 
+#include "GAUDI_VERSION.h"
+
+#if GAUDI_MAJOR_VERSION < 40
+namespace Gaudi::Accumulators {
+  using StaticRootHistogram = Gaudi::Accumulators::RootHistogram;
+}
+#endif
+
 struct ExampleFunctionalTransformerHist final
     : k4FWCore::Transformer<edm4hep::MCParticleCollection(const edm4hep::MCParticleCollection& input)> {
+  StatusCode initialize() override {
+#if GAUDI_MAJOR_VERSION >= 40
+    m_customHistogram.createHistogram(*this);
+#endif
+    return StatusCode::SUCCESS;
+  }
   // The pairs in KeyValues can be changed from python and they correspond
   // to the name of the input and output collections respectively
   ExampleFunctionalTransformerHist(const std::string& name, ISvcLocator* svcLoc)
@@ -36,14 +50,25 @@ struct ExampleFunctionalTransformerHist final
   // This is the function that will be called to produce the data
   edm4hep::MCParticleCollection operator()(const edm4hep::MCParticleCollection& input) const override {
     // Fill the histogram with the energy of one particle
-    ++m_histograms[input[0 + !m_firstParticle.value()].getEnergy()];
+    ++m_histogram[input[0 + !m_firstParticle.value()].getEnergy()];
+#if GAUDI_MAJOR_VERSION >= 40
+    ++m_customHistogram[input[0 + !m_firstParticle.value()].getEnergy()];
+#endif
     // Return an empty collection since we don't care about the collection
     return {};
   }
 
 private:
   // This is the histogram that will be filled, 1 is the number of dimensions of the histogram (1D)
-  mutable Gaudi::Accumulators::RootHistogram<1> m_histograms{this, "Histogram Name", "Histogram Title", {100, 0, 10.}};
+  mutable Gaudi::Accumulators::StaticRootHistogram<1> m_histogram{
+      this, "Histogram Name", "Histogram Title", {100, 0, 10.}};
+
+public:
+#if GAUDI_MAJOR_VERSION >= 40
+  // This is a histogram with title, name and bins that can be set from python
+  void registerCallBack(Gaudi::StateMachine::Transition, std::function<void()>) {}
+  mutable Gaudi::Accumulators::RootHistogram<1> m_customHistogram{this, "CustomHistogram"};
+#endif
 
   Gaudi::Property<bool> m_firstParticle{this, "FirstParticle", true};
 };

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
@@ -68,6 +68,7 @@ private:
 public:
 #if GAUDI_MAJOR_VERSION >= 39
   // This is a histogram with title, name and bins that can be set from python
+  // The callback function is only needed for these histograms with configurable properties
   void registerCallBack(Gaudi::StateMachine::Transition, std::function<void()>) {}
   mutable Gaudi::Accumulators::RootHistogram<1> m_customHistogram{this, "CustomHistogram"};
 #endif

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
@@ -27,7 +27,7 @@
 
 #include "GAUDI_VERSION.h"
 
-#if GAUDI_MAJOR_VERSION < 40
+#if GAUDI_MAJOR_VERSION < 39
 namespace Gaudi::Accumulators {
   using StaticRootHistogram = Gaudi::Accumulators::RootHistogram;
 }
@@ -36,7 +36,7 @@ namespace Gaudi::Accumulators {
 struct ExampleFunctionalTransformerHist final
     : k4FWCore::Transformer<edm4hep::MCParticleCollection(const edm4hep::MCParticleCollection& input)> {
   StatusCode initialize() override {
-#if GAUDI_MAJOR_VERSION >= 40
+#if GAUDI_MAJOR_VERSION >= 39
     m_customHistogram.createHistogram(*this);
 #endif
     return StatusCode::SUCCESS;
@@ -51,7 +51,7 @@ struct ExampleFunctionalTransformerHist final
   edm4hep::MCParticleCollection operator()(const edm4hep::MCParticleCollection& input) const override {
     // Fill the histogram with the energy of one particle
     ++m_histogram[input[0 + !m_firstParticle.value()].getEnergy()];
-#if GAUDI_MAJOR_VERSION >= 40
+#if GAUDI_MAJOR_VERSION >= 39
     ++m_customHistogram[input[0 + !m_firstParticle.value()].getEnergy()];
 #endif
     // Return an empty collection since we don't care about the collection
@@ -64,7 +64,7 @@ private:
       this, "Histogram Name", "Histogram Title", {100, 0, 10.}};
 
 public:
-#if GAUDI_MAJOR_VERSION >= 40
+#if GAUDI_MAJOR_VERSION >= 39
   // This is a histogram with title, name and bins that can be set from python
   void registerCallBack(Gaudi::StateMachine::Transition, std::function<void()>) {}
   mutable Gaudi::Accumulators::RootHistogram<1> m_customHistogram{this, "CustomHistogram"};

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
@@ -29,7 +29,9 @@
 
 #if GAUDI_MAJOR_VERSION < 39
 namespace Gaudi::Accumulators {
-  using StaticRootHistogram = Gaudi::Accumulators::RootHistogram;
+  template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
+  using StaticRootHistogram =
+      Gaudi::Accumulators::RootHistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString>;
 }
 #endif
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix histograms for Gaudi v39. After https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1586 the "old" histograms are renamed to  `StaticRootHistogram` from `RootHistogram`
- Add a configurable histogram: `RootHistogram`, whose bins, title and other properties can be set from python as shown in the test file

ENDRELEASENOTES