### PR TITLE
change python formatter to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,10 @@ repos:
         "-x", ".github/*", ".pre-commit-config.yaml", "README.md",
               "doc/ReleaseNotes.md", ".k4fwcore-ci.d/*",
         "-f"]
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
+  - repo: local
     hooks:
-      - id: black
+      - id: ruff-format
+        name: ruff-format
+        entry: ruff format --force-exclude
+        types: [python]
+        language: system

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,10 @@
+target-version = "py311"
+
+line-length = 99
+
+[format]
+# Make things format the same way as black
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"

--- a/k4FWCore/scripts/k4-print-joboptions
+++ b/k4FWCore/scripts/k4-print-joboptions
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
-"""
-
-
-"""
+""" """
 
 from __future__ import print_function
 import argparse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[tool.black]
-line-length = 99
-target-version = ["py310"]


### PR DESCRIPTION
BEGINRELEASENOTES
- Changed python formatter to ruff

ENDRELEASENOTES

Changing black to ruff and updating the config to use target "py311" as in key4hep/k4geo#398 and key4hep/EDM4hep#370