### PR TITLE
Use `std::unique_ptr<podio::CollectionBase>` to save collections in the store and fix leak in the Writer

### DIFF
--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -39,7 +39,7 @@ public:
    * @brief Read the next event from the input file
    * @return A tuple containing the collections read, the collection names and the frame that owns the collections
    */
-  virtual std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std::string>, podio::Frame>
+  virtual std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame>
                                                     next()                     = 0;
   virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
 

--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -39,9 +39,8 @@ public:
    * @brief Read the next event from the input file
    * @return A tuple containing the collections read, the collection names and the frame that owns the collections
    */
-  virtual std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame>
-                                                    next()                     = 0;
-  virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
+  virtual std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next() = 0;
+  virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const                           = 0;
 
   virtual podio::Writer& getWriter()                                         = 0;
   virtual void           deleteWriter()                                      = 0;

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -109,15 +109,14 @@ StatusCode IOSvc::initialize() {
 
 StatusCode IOSvc::finalize() { return Service::finalize(); }
 
-std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std::string>, podio::Frame> IOSvc::next() {
+std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> IOSvc::next() {
   podio::Frame frame;
   {
     std::scoped_lock<std::mutex> lock(m_changeBufferLock);
     if (m_nextEntry < m_entries) {
       frame = podio::Frame(m_reader->readEvent(m_nextEntry));
     } else {
-      return std::make_tuple(std::vector<std::shared_ptr<podio::CollectionBase>>(), std::vector<std::string>(),
-                             std::move(frame));
+      return std::make_tuple(std::vector<podio::CollectionBase*>(), std::vector<std::string>(), std::move(frame));
     }
     m_nextEntry++;
     if (m_collectionNames.empty()) {
@@ -134,11 +133,11 @@ std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std:
     }
   }
 
-  std::vector<std::shared_ptr<podio::CollectionBase>> collections;
+  std::vector<podio::CollectionBase*> collections;
 
   for (const auto& name : m_collectionNames) {
     auto ptr = const_cast<podio::CollectionBase*>(frame.get(name));
-    collections.push_back(std::shared_ptr<podio::CollectionBase>(ptr));
+    collections.push_back(ptr);
   }
 
   return std::make_tuple(collections, m_collectionNames, std::move(frame));

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -43,8 +43,7 @@ public:
   StatusCode initialize() override;
   StatusCode finalize() override;
 
-  std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next()
-      override;
+  std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next() override;
 
   std::shared_ptr<std::vector<std::string>> getCollectionNames() const override {
     return std::make_shared<std::vector<std::string>>(m_collectionNames);

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -43,7 +43,7 @@ public:
   StatusCode initialize() override;
   StatusCode finalize() override;
 
-  std::tuple<std::vector<std::shared_ptr<podio::CollectionBase>>, std::vector<std::string>, podio::Frame> next()
+  std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next()
       override;
 
   std::shared_ptr<std::vector<std::string>> getCollectionNames() const override {

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -19,9 +19,9 @@
 #ifndef FWCORE_CONSUMER_H
 #define FWCORE_CONSUMER_H
 
-#include <GaudiKernel/FunctionalFilterDecision.h>
 #include "Gaudi/Functional/details.h"
 #include "Gaudi/Functional/utilities.h"
+#include "GaudiKernel/FunctionalFilterDecision.h"
 
 // #include "GaudiKernel/CommonMessaging.h"
 
@@ -43,14 +43,13 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
                     "Consumer input types must be EDM4hep collections or vectors of collection pointers");
 
-      template <typename T>
-      using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, std::remove_pointer_t<T>>;
+      template <typename T> using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, T>;
 
-      std::tuple<std::vector<InputHandle_t<typename transformType<In>::type>>...> m_inputs;
-      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>          m_inputLocations{};
+      std::tuple<std::vector<InputHandle_t<typename EventStoreType<In>::type>>...> m_inputs;
+      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>           m_inputLocations{};
 
       using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
 
@@ -66,9 +65,9 @@ namespace k4FWCore {
             m_inputLocations{Gaudi::Property<std::vector<DataObjID>>{
                 this, std::get<I>(inputs).first, to_DataObjID(std::get<I>(inputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
-                  std::vector<InputHandle_t<typename transformType<In>::type>> handles;
+                  std::vector<InputHandle_t<EventStoreType_t>> handles;
                   for (auto& value : this->m_inputLocations[I].value()) {
-                    auto handle = InputHandle_t<typename transformType<In>::type>(value, this);
+                    auto handle = InputHandle_t<EventStoreType_t>(value, this);
                     handles.push_back(std::move(handle));
                   }
                   std::get<I>(m_inputs) = std::move(handles);

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -43,7 +43,7 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
                     "Consumer input types must be EDM4hep collections or vectors of collection pointers");
 
       template <typename T> using InputHandle_t = Gaudi::Functional::details::InputHandle_t<Traits_, T>;

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -27,8 +27,6 @@
 
 #include "edm4hep/Constants.h"
 
-#include "TTree.h"
-
 #include <GaudiKernel/AnyDataWrapper.h>
 #include <type_traits>
 
@@ -133,9 +131,9 @@ template <typename T> const T* DataHandle<T>::get() {
       return reinterpret_cast<const T*>(tmp->collectionBase());
     } else {
       // When a functional has pushed a std::shared_ptr<podio::CollectionBase> into the store
-      auto ptr = static_cast<AnyDataWrapper<std::shared_ptr<podio::CollectionBase>>*>(dataObjectp)->getData();
+      auto ptr = static_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(dataObjectp);
       if (ptr) {
-        return reinterpret_cast<const T*>(ptr.get());
+        return static_cast<const T*>(ptr->getData().get());
       }
       std::string errorMsg("The type provided for " + DataObjectHandle<DataWrapper<T>>::pythonRepr() +
                            " is different from the one of the object in the store.");

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -41,7 +41,7 @@ public:
   template <class T2> friend class DataHandle;
 
 public:
-  DataWrapper() : m_data(nullptr) {};
+  DataWrapper() : m_data(nullptr){}
   DataWrapper(T&& coll) {
     m_data   = new T(std::move(coll));
     is_owner = true;
@@ -49,7 +49,7 @@ public:
   DataWrapper(std::unique_ptr<T> uptr) : m_data(uptr.get()) {
     uptr.release();
     is_owner = false;
-  };
+  }
   virtual ~DataWrapper();
 
   const T* getData() const { return m_data; }

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -41,7 +41,7 @@ public:
   template <class T2> friend class DataHandle;
 
 public:
-  DataWrapper() : m_data(nullptr){};
+  DataWrapper() : m_data(nullptr) {};
   DataWrapper(T&& coll) {
     m_data   = new T(std::move(coll));
     is_owner = true;

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -41,7 +41,7 @@ public:
   template <class T2> friend class DataHandle;
 
 public:
-  DataWrapper() : m_data(nullptr){}
+  DataWrapper() : m_data(nullptr) {}
   DataWrapper(T&& coll) {
     m_data   = new T(std::move(coll));
     is_owner = true;

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -48,7 +48,6 @@ namespace k4FWCore {
     };
     using EventStoreType_t = typename EventStoreType<void>::type;
 
-
     template <typename T, typename P>
       requires(!std::is_same_v<P, podio::CollectionBase*>)
     const auto& maybeTransformToEDM4hep(const P& arg) {
@@ -92,8 +91,8 @@ namespace k4FWCore {
       // returned from the algorithm
       if constexpr (std::same_as<T, podio::CollectionBase*>) {
         return std::unique_ptr<podio::CollectionBase>(std::forward<T>(arg));
-      // Most common case, when an algorithm returns a collection and
-      // we want to store a unique_ptr
+        // Most common case, when an algorithm returns a collection and
+        // we want to store a unique_ptr
       } else {
         return std::make_unique<T>(std::forward<T>(arg));
       }

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -43,7 +43,7 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
                     "Transformer and Producer input types must be EDM4hep collections or vectors of collections");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out> ||
                      std::is_same_v<podio::CollectionBase*, Out>),

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -43,10 +43,10 @@ namespace k4FWCore {
         : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
       using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
 
-      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>)&&...),
+      static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In>) && ...),
                     "Transformer and Producer input types must be EDM4hep collections or vectors of collections");
       static_assert((std::is_base_of_v<podio::CollectionBase, Out> || isVectorLike_v<Out> ||
-                     std::is_same_v<std::shared_ptr<podio::CollectionBase>, Out>),
+                     std::is_same_v<podio::CollectionBase*, Out>),
                     "Transformer and Producer output types must be EDM4hep collections or vectors of collections");
 
       template <typename T>
@@ -56,8 +56,8 @@ namespace k4FWCore {
 
       std::tuple<std::vector<InputHandle_t<typename EventStoreType<In>::type>>...> m_inputs;
       std::tuple<std::vector<OutputHandle_t<typename EventStoreType<Out>::type>>>  m_outputs;
-      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>          m_inputLocations{};
-      Gaudi::Property<std::vector<DataObjID>>                                     m_outputLocations{};
+      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>           m_inputLocations{};
+      Gaudi::Property<std::vector<DataObjID>>                                      m_outputLocations{};
 
       using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
 
@@ -117,7 +117,7 @@ namespace k4FWCore {
           } else {
             Gaudi::Functional::details::put(
                 std::get<0>(this->m_outputs)[0],
-                convertToSharedPtr(std::move(filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs))));
+                convertToUniquePtr(std::move(filter_evtcontext_tt<In...>::apply(*this, ctx, this->m_inputs))));
           }
           return Gaudi::Functional::FilterDecision::PASSED;
         } catch (GaudiException& e) {
@@ -194,8 +194,8 @@ namespace k4FWCore {
 
       std::tuple<std::vector<InputHandle_t<typename EventStoreType<In>::type>>...>   m_inputs;
       std::tuple<std::vector<OutputHandle_t<typename EventStoreType<Out>::type>>...> m_outputs;
-      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>            m_inputLocations{};
-      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(Out)>           m_outputLocations{};
+      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>             m_inputLocations{};
+      std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(Out)>            m_outputLocations{};
 
       using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
 

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -54,8 +54,8 @@ namespace k4FWCore {
       template <typename T>
       using OutputHandle_t = Gaudi::Functional::details::OutputHandle_t<Traits_, std::remove_pointer_t<T>>;
 
-      std::tuple<std::vector<InputHandle_t<typename transformType<In>::type>>...> m_inputs;
-      std::tuple<std::vector<OutputHandle_t<typename transformType<Out>::type>>>  m_outputs;
+      std::tuple<std::vector<InputHandle_t<typename EventStoreType<In>::type>>...> m_inputs;
+      std::tuple<std::vector<OutputHandle_t<typename EventStoreType<Out>::type>>>  m_outputs;
       std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>          m_inputLocations{};
       Gaudi::Property<std::vector<DataObjID>>                                     m_outputLocations{};
 
@@ -75,9 +75,9 @@ namespace k4FWCore {
             m_inputLocations{Gaudi::Property<std::vector<DataObjID>>{
                 this, std::get<I>(inputs).first, to_DataObjID(std::get<I>(inputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
-                  std::vector<InputHandle_t<typename transformType<In>::type>> h;
+                  std::vector<InputHandle_t<typename EventStoreType<In>::type>> h;
                   for (auto& value : this->m_inputLocations[I].value()) {
-                    auto handle = InputHandle_t<typename transformType<In>::type>(value, this);
+                    auto handle = InputHandle_t<typename EventStoreType<In>::type>(value, this);
                     h.push_back(std::move(handle));
                   }
                   std::get<I>(m_inputs) = std::move(h);
@@ -87,12 +87,12 @@ namespace k4FWCore {
             m_outputLocations{Gaudi::Property<std::vector<DataObjID>>{
                 this, std::get<J>(outputs).first, to_DataObjID(std::get<J>(outputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
-                  std::vector<OutputHandle_t<typename transformType<Out>::type>> h;
+                  std::vector<OutputHandle_t<typename EventStoreType<Out>::type>> h;
                   for (auto& inpID : this->m_outputLocations.value()) {
                     if (inpID.key().empty()) {
                       continue;
                     }
-                    auto handle = OutputHandle_t<typename transformType<Out>::type>(inpID, this);
+                    auto handle = OutputHandle_t<typename EventStoreType<Out>::type>(inpID, this);
                     h.push_back(std::move(handle));
                   }
                   std::get<0>(m_outputs) = std::move(h);
@@ -192,8 +192,8 @@ namespace k4FWCore {
       template <typename T>
       using OutputHandle_t = Gaudi::Functional::details::OutputHandle_t<Traits_, std::remove_pointer_t<T>>;
 
-      std::tuple<std::vector<InputHandle_t<typename transformType<In>::type>>...>   m_inputs;
-      std::tuple<std::vector<OutputHandle_t<typename transformType<Out>::type>>...> m_outputs;
+      std::tuple<std::vector<InputHandle_t<typename EventStoreType<In>::type>>...>   m_inputs;
+      std::tuple<std::vector<OutputHandle_t<typename EventStoreType<Out>::type>>...> m_outputs;
       std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(In)>            m_inputLocations{};
       std::array<Gaudi::Property<std::vector<DataObjID>>, sizeof...(Out)>           m_outputLocations{};
 
@@ -208,9 +208,9 @@ namespace k4FWCore {
             m_inputLocations{Gaudi::Property<std::vector<DataObjID>>{
                 this, std::get<I>(inputs).first, to_DataObjID(std::get<I>(inputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
-                  std::vector<InputHandle_t<typename transformType<In>::type>> h;
+                  std::vector<InputHandle_t<typename EventStoreType<In>::type>> h;
                   for (auto& value : this->m_inputLocations[I].value()) {
-                    auto handle = InputHandle_t<typename transformType<In>::type>(value, this);
+                    auto handle = InputHandle_t<typename EventStoreType<In>::type>(value, this);
                     h.push_back(std::move(handle));
                   }
                   std::get<I>(m_inputs) = std::move(h);
@@ -219,7 +219,7 @@ namespace k4FWCore {
             m_outputLocations{Gaudi::Property<std::vector<DataObjID>>{
                 this, std::get<J>(outputs).first, to_DataObjID(std::get<J>(outputs).second),
                 [this](Gaudi::Details::PropertyBase&) {
-                  std::vector<OutputHandle_t<typename transformType<Out>::type>> h;
+                  std::vector<OutputHandle_t<typename EventStoreType<Out>::type>> h;
                   // Is this needed?
                   // std::sort(this->m_outputLocations[J].value().begin(), this->m_outputLocations[J].value().end(),
                   //           [](const DataObjID& a, const DataObjID& b) { return a.key() < b.key(); });
@@ -227,7 +227,7 @@ namespace k4FWCore {
                     if (inpID.key().empty()) {
                       continue;
                     }
-                    auto handle = OutputHandle_t<typename transformType<Out>::type>(inpID, this);
+                    auto handle = OutputHandle_t<typename EventStoreType<Out>::type>(inpID, this);
                     h.push_back(std::move(handle));
                   }
                   std::get<J>(m_outputs) = std::move(h);


### PR DESCRIPTION
See https://github.com/key4hep/k4FWCore/issues/249 for the report of the leak.

BEGINRELEASENOTES
- Use `std::unique_ptr<podio::CollectionBase>` for the collections in the store instead of `std::shared_ptr<podio::CollectionBase>`. 
- Fix leak in the `Writer` that otherwise would have been difficult to fix (without the change above)
- Clean up `FunctionalUtils.h`: remove some unused overloads and change some names.

ENDRELEASENOTES

`shared_ptr` was supposed to be temporary until everything worked, so it was a good time to remove it. 
