### PR TITLE
add EventCounter algorithm

### DIFF
--- a/k4FWCore/components/EventCounter.cpp
+++ b/k4FWCore/components/EventCounter.cpp
@@ -31,6 +31,11 @@ public:
     }
   }
 
+  StatusCode finalize() override {
+    info() << "Processed " << m_count.value() << " events" << endmsg;
+    return Consumer::finalize();
+  }
+
 private:
   mutable Gaudi::Accumulators::Counter<> m_count{this, "count"};
   Gaudi::Property<unsigned int>          m_frequency{this, "Frequency", 1, "How often to print the event number"};

--- a/k4FWCore/components/EventCounter.cpp
+++ b/k4FWCore/components/EventCounter.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Gaudi/Accumulators.h"
+#include "Gaudi/Functional/Consumer.h"
+
+class EventCounter final : public Gaudi::Functional::Consumer<void(const EventContext&)> {
+public:
+  using Consumer::Consumer;
+
+  void operator()(const EventContext& ctx) const override {
+    ++m_count;
+    if ((m_frequency > 0) && (ctx.evt() % m_frequency == 0)) {
+      info() << "Processing event " << ctx.evt() << endmsg;
+    }
+  }
+
+private:
+  mutable Gaudi::Accumulators::Counter<> m_count{this, "count"};
+  Gaudi::Property<int>                   m_frequency{this, "Frequency", 1, "How often to print the event number"};
+};
+
+DECLARE_COMPONENT(EventCounter)

--- a/k4FWCore/components/EventCounter.cpp
+++ b/k4FWCore/components/EventCounter.cpp
@@ -26,14 +26,14 @@ public:
 
   void operator()(const EventContext& ctx) const override {
     ++m_count;
-    if ((m_frequency > 0) && (ctx.evt() % m_frequency == 0)) {
+    if (m_frequency && (ctx.evt() % m_frequency == 0)) {
       info() << "Processing event " << ctx.evt() << endmsg;
     }
   }
 
 private:
   mutable Gaudi::Accumulators::Counter<> m_count{this, "count"};
-  Gaudi::Property<int>                   m_frequency{this, "Frequency", 1, "How often to print the event number"};
+  Gaudi::Property<unsigned int>          m_frequency{this, "Frequency", 1, "How often to print the event number"};
 };
 
 DECLARE_COMPONENT(EventCounter)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -139,6 +139,8 @@ add_test_with_env(Testk4runCustomArguments options/TestArgs.py --foo=42 PROPERTI
 add_test_with_env(Testk4runVerboseOutput options/TestArgs.py --verbose PROPERTIES PASS_REGULAR_EXPRESSION " VERBOSE ")
 add_test_with_env(Testk4runHelpOnly options/TestArgs.py --help PROPERTIES PASS_REGULAR_EXPRESSION "show this help message and exit")
 
+add_test_with_env(TestEventCounter options/TestEventCounter.py)
+set_tests_properties(TestEventCounter PROPERTIES FAIL_REGULAR_EXPRESSION "Processing event 1;Processing event 3" PASS_REGULAR_EXPRESSION "Processing event 0.*Processing event 2;Processing event 2.*Processing event 0")
 
 add_test_with_env(FunctionalMemory options/ExampleFunctionalMemory.py)
 add_test_with_env(FunctionalMTMemory options/ExampleFunctionalMTMemory.py)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -140,7 +140,8 @@ add_test_with_env(Testk4runVerboseOutput options/TestArgs.py --verbose PROPERTIE
 add_test_with_env(Testk4runHelpOnly options/TestArgs.py --help PROPERTIES PASS_REGULAR_EXPRESSION "show this help message and exit")
 
 add_test_with_env(TestEventCounter options/TestEventCounter.py)
-set_tests_properties(TestEventCounter PROPERTIES FAIL_REGULAR_EXPRESSION "Processing event 1;Processing event 3" PASS_REGULAR_EXPRESSION "Processing event 0.*Processing event 2;Processing event 2.*Processing event 0")
+set_tests_properties(TestEventCounter PROPERTIES FAIL_REGULAR_EXPRESSION "Processing event 1;Processing event 3"
+                     PASS_REGULAR_EXPRESSION "(Processing event 0.*Processing event 2|Processing event 2.*Processing event 0).*Processed 4 events.*Processed 4 events")
 
 add_test_with_env(FunctionalMemory options/ExampleFunctionalMemory.py)
 add_test_with_env(FunctionalMTMemory options/ExampleFunctionalMTMemory.py)

--- a/test/k4FWCoreTest/options/TestEventCounter.py
+++ b/test/k4FWCoreTest/options/TestEventCounter.py
@@ -52,7 +52,9 @@ mgr = ApplicationMgr(
     TopAlg=[counter_1, counter_2],
     EvtSel="NONE",
     EvtMax=4,
-    ExtSvc=[whiteboard, "Gaudi::Monitoring::MessageSvcSink"],
+    # Add "MessageSvcSink" for a table at the end with a statistical summary of the counter data
+    # ExtSvc=[whiteboard, "Gaudi::Monitoring::MessageSvcSink"],
+    ExtSvc=[whiteboard],
     EventLoop=slimeventloopmgr,
     OutputLevel=INFO,
 )

--- a/test/k4FWCoreTest/options/TestEventCounter.py
+++ b/test/k4FWCoreTest/options/TestEventCounter.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an example of counting events with EventCounter algorithm.
+# During execution the EventCounter algorithms will printout current event number depending on the frequency.
+# The summary about total number of events passed through that algorithms is handled by MessageSvcSink
+
+from Gaudi.Configuration import INFO, WARNING
+from Configurables import EventCounter
+from Configurables import HiveSlimEventLoopMgr, HiveWhiteBoard, AvalancheSchedulerSvc
+from k4FWCore import ApplicationMgr
+
+evtslots = 4
+threads = 4
+
+whiteboard = HiveWhiteBoard(
+    "EventDataSvc",
+    EventSlots=evtslots,
+    ForceLeaves=True,
+)
+
+slimeventloopmgr = HiveSlimEventLoopMgr(
+    "HiveSlimEventLoopMgr",
+    SchedulerName="AvalancheSchedulerSvc",
+    Warnings=False,
+    OutputLevel=WARNING,
+)
+
+scheduler = AvalancheSchedulerSvc(ThreadPoolSize=threads, ShowDataFlow=True, OutputLevel=WARNING)
+
+counter_1 = EventCounter("SilentEventCounter", Frequency=0, OutputLevel=INFO)
+counter_2 = EventCounter("EventCounter", Frequency=2, OutputLevel=INFO)
+
+
+mgr = ApplicationMgr(
+    TopAlg=[counter_1, counter_2],
+    EvtSel="NONE",
+    EvtMax=4,
+    ExtSvc=[whiteboard, "Gaudi::Monitoring::MessageSvcSink"],
+    EventLoop=slimeventloopmgr,
+    OutputLevel=INFO,
+)


### PR DESCRIPTION
BEGINRELEASENOTES
- Added thread-safe`EventCounter` algorithm

ENDRELEASENOTES

Adding thread-safe version of `EventCounter` algorithm. The algorithm will print current event number (as seen by the scheduler) depending on the frequency. Counting the total number of events passed through the algorithm is done with `Gaudi::Accumulators::Counter` - add `MessageSvcSink` in order to get a printout about all the Gaudi counters, for instance:
```txt
26: ApplicationMgr       INFO Application Manager Initialized successfully
26: ApplicationMgr       INFO Application Manager Started successfully
26: EventCounter         INFO Processing event 0
26: EventCounter         INFO Processing event 2
26: EventCounter         INFO Number of counters : 1
26:  |    Counter                                      |     #     |    sum     | mean/eff^* | rms/err^*  |     min     |     max     |
26:  | "count"                                         |         4 |
26: SilentEventCounter   INFO Number of counters : 1
26:  |    Counter                                      |     #     |    sum     | mean/eff^* | rms/err^*  |     min     |     max     |
26:  | "count"                                         |         4 |
26: ApplicationMgr       INFO Application Manager Stopped successfully
26: SilentEventCounter   INFO Processed 4 events
26: EventCounter         INFO Processed 4 events
26: ApplicationMgr       INFO Application Manager Finalized successfully
26: ApplicationMgr       INFO Application Manager Terminated successfully
```

Closes #219 
