### PR TITLE
Fix DataHandle::get() for non-collection types and remove dead code

### DIFF
--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -25,8 +25,8 @@
 #include "GaudiKernel/DataObjectHandle.h"
 
 #include <GaudiKernel/AnyDataWrapper.h>
-#include <type_traits>
 #include <stdexcept>
+#include <type_traits>
 
 /**
  * Specialisation of the Gaudi DataHandle

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -26,6 +26,7 @@
 
 #include <GaudiKernel/AnyDataWrapper.h>
 #include <type_traits>
+#include <stdexcept>
 
 /**
  * Specialisation of the Gaudi DataHandle
@@ -123,8 +124,8 @@ template <typename T> const T* DataHandle<T>::get() {
     return static_cast<const T*>(ptr->getData().get());
   }
   std::string errorMsg("The type provided for " + DataObjectHandle<DataWrapper<T>>::pythonRepr() +
-                       " is different from the one of the object in the store.");
-  throw GaudiException(errorMsg, "wrong product type", StatusCode::FAILURE);
+                       " is different from the one of the object in the store " + typeid(*dataObjectp).name());
+  throw std::runtime_error(errorMsg);
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix DataHandle::get() for non-collection types and remove dead code. A `reinterpret_cast` was changed to `static_cast` in https://github.com/key4hep/k4FWCore/pull/250 that made it fail at compile time for non-collection types. Now the `static_cast` is properly wrapped around an `if constexpr` and code around it has been deleted since it looked impossible to trigger.

ENDRELEASENOTES