### PR TITLE
Don't add duplicated options for ToolSvcs

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -67,7 +67,10 @@ def add_arguments(parser, app_mgr):
     # can contain the same value multiple times
     # see https://github.com/key4hep/k4FWCore/issues/141
     for conf in frozenset(app_mgr.allConfigurables.values()):
-        if conf.name() in ["ApplicationMgr", "ToolSvc", "k4FWCore__Sequencer", "k4FWCore__Algs"]:
+        # ToolSvcs will have their properties duplicated, once as the
+        # named service itself and another one as "ToolSvc" if it's not
+        # excluded here
+        if any(name in conf.name() for name in ["ApplicationMgr", "ToolSvc"]):
             continue
         for prop_name, prop_value in conf.getPropertiesWithDescription().items():
             if (


### PR DESCRIPTION
BEGINRELEASENOTES
- Don't add duplicated options for ToolSvcs

ENDRELEASENOTES

The logic was incorrect since the name will never be exactly `ToolSvc` so the check has to be if `ToolSvc` is contained. This removes the duplicated argument in one of the tests in k4Gen. The cases for Sequencer and Algs seem to never ocurred, I checked on all the tests that we have.

If CI is happy I'll merge today so that the fix is on the nightlies for tomorrow and the downstream build gets further.