### PR TITLE
fix: require podio 1.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,7 @@ project(k4FWCore)
 
 find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
-  find_package(podio 0.16.3)  # this will not find 1.0 and newer
-  if(NOT podio_FOUND)
-    # we try to find a newer version now
-    find_package(podio 1.0 REQUIRED)
-  endif()
+find_package(podio 1.0.1 REQUIRED)
 find_package(EDM4HEP REQUIRED)
 
 include(cmake/Key4hepConfig.cmake)


### PR DESCRIPTION
BEGINRELEASENOTES
- Require podio 1.0.1 in CMake

ENDRELEASENOTES

Since https://github.com/key4hep/k4FWCore/pull/233, k4FWCore requires podioIO as a target. That's only available as https://github.com/AIDASoft/podio/commit/6eefdc42bcdc26652f20af398429826c0bfff54f, or tag v01-00-01. This change should be propagated to key4hep-spack as well, and k4FWCore should be tested in CI against oldest allowed versions. Tagging @tmadlener @jmcarcell.