### PR TITLE
Write the configuration_metadata at initialize() in the Writer

### DIFF
--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -82,10 +82,6 @@ public:
       return StatusCode::FAILURE;
     }
 
-    return StatusCode::SUCCESS;
-  }
-
-  StatusCode finalize() override {
     podio::Frame config_metadata_frame;
 
     //// prepare job options metadata ///////////////////////
@@ -104,7 +100,7 @@ public:
     }
     // Some default components are not captured by the job option service
     // and have to be traversed like this. Note that Gaudi!577 will improve this.
-    for (const auto* name : {"NTupleSvc"}) {
+    for (const auto* name : {"ApplicationMgr", "MessageSvc", "NTupleSvc"}) {
       std::stringstream config_stream;
       auto              svc = service<IProperty>(name);
       if (!svc.isValid())
@@ -121,6 +117,10 @@ public:
     }
     iosvc->getWriter().writeFrame(config_metadata_frame, "configuration_metadata");
 
+    return StatusCode::SUCCESS;
+  }
+
+  StatusCode finalize() override {
     if (const auto* metadata_frame = m_metadataSvc->getFrame(); metadata_frame) {
       iosvc->getWriter().writeFrame(*metadata_frame, podio::Category::Metadata);
     }

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -114,7 +114,7 @@ add_test(NAME AlgorithmWithTFileCheckMyTFileOutput
 set_property(TEST AlgorithmWithTFileCheckMyTFileOutput APPEND PROPERTY DEPENDS AlgorithmWithTFile)
 set_test_env(AlgorithmWithTFileCheckMyTFileOutput)
 
-add_test_with_env(CreateExampleEventData_cellID options/createExampleEventData_cellID.py)
+add_test_with_env(CreateExampleEventData_cellID options/createExampleEventData_cellID.py ADD_TO_CHECK_FILES)
 add_test_with_env(TwoProducers options/TwoProducers.py --filename output_k4fwcore_test_twoproducer.root
                   --magicNumberOffset.Producer2 12345 --Producer1.magicNumberOffset 54321)
 add_test_with_env(CheckCommandLineArguments options/createHelloWorld.py --HelloWorldAlg1.PerEventPrintMessage TwasBrilligAndTheSlithyToves

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
@@ -30,7 +30,18 @@ from Configurables import EventDataSvc
 iosvc = IOSvc()
 iosvc.Output = "functional_metadata.root"
 
-producer = ExampleFunctionalMetadataProducer("Producer", OutputCollection=["MCParticles"])
+producer = ExampleFunctionalMetadataProducer(
+    "Producer",
+    intProp2=69,
+    floatProp2=2.71828,
+    doubleProp2=2.7182818,
+    stringProp2="Hello, World!",
+    vectorIntProp2=[1, 2, 3, 4],
+    vectorFloatProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorDoubleProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorStringProp2=["one", "two", "three", "four"],
+    OutputCollection=["MCParticles"],
+)
 consumer = ExampleFunctionalMetadataConsumer("Consumer", InputCollection=["MCParticles"])
 
 ApplicationMgr(

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadataOldAlgorithm.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadataOldAlgorithm.py
@@ -23,7 +23,17 @@ from k4FWCore import ApplicationMgr, IOSvc
 iosvc = IOSvc()
 iosvc.Output = "functional_metadata_old_algorithm.root"
 
-producer = k4FWCoreTest_cellID_writer()
+producer = k4FWCoreTest_cellID_writer(
+    "CellIDWriter",
+    intProp2=69,
+    floatProp2=2.71828,
+    doubleProp2=2.7182818,
+    stringProp2="Hello, World!",
+    vectorIntProp2=[1, 2, 3, 4],
+    vectorFloatProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorDoubleProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorStringProp2=["one", "two", "three", "four"],
+)
 consumer = k4FWCoreTest_cellID_reader()
 
 

--- a/test/k4FWCoreTest/options/createExampleEventData_cellID.py
+++ b/test/k4FWCoreTest/options/createExampleEventData_cellID.py
@@ -26,7 +26,17 @@ from k4FWCore import ApplicationMgr
 podioevent = k4DataSvc("EventDataSvc")
 
 
-producer = k4FWCoreTest_cellID_writer()
+producer = k4FWCoreTest_cellID_writer(
+    "CellIDWriter",
+    intProp2=69,
+    floatProp2=2.71828,
+    doubleProp2=2.7182818,
+    stringProp2="Hello, World!",
+    vectorIntProp2=[1, 2, 3, 4],
+    vectorFloatProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorDoubleProp2=[1.1, 2.2, 3.3, 4.4],
+    vectorStringProp2=["one", "two", "three", "four"],
+)
 consumer = k4FWCoreTest_cellID_reader()
 
 

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -254,3 +254,47 @@ for name, events in {
     "functional_transformer_cli_multiple.root": 20,
 }.items():
     check_events(name, events)
+
+
+for i, filename in enumerate(
+    [
+        "output_k4test_exampledata_cellid.root",
+        "functional_metadata_old_algorithm.root",
+        "functional_metadata.root",
+    ]
+):
+    reader = podio.root_io.Reader(filename)
+    configuration_metadata = reader.get("configuration_metadata")[0].get_parameter(
+        "gaudiConfigOptions"
+    )
+    configuration_metadata = [elem.strip(" ,;\n") for elem in configuration_metadata]
+    configuration_metadata = {
+        elem.split("=")[0]: elem.split("=")[1] for elem in configuration_metadata
+    }
+
+    props_and_values = {
+        "intProp": '"42"',
+        "intProp2": '"69"',
+        "floatProp": '"3.14000"',
+        "floatProp2": '"2.71828"',
+        "doubleProp": '"3.1400000"',
+        "doubleProp2": '"2.7182818"',
+        "stringProp": "\"'Hello'\"",
+        "stringProp2": "\"'Hello, World!'\"",
+        "vectorIntProp": '"[ 1 , 2 , 3 ]"',
+        "vectorIntProp2": '"[ 1 , 2 , 3 , 4 ]"',
+        "vectorFloatProp": '"[ 1.10000 , 2.20000 , 3.30000 ]"',
+        "vectorFloatProp2": '"[ 1.10000 , 2.20000 , 3.30000 , 4.40000 ]"',
+        "vectorDoubleProp": '"[ 1.1000000 , 2.2000000 , 3.3000000 ]"',
+        "vectorDoubleProp2": '"[ 1.1000000 , 2.2000000 , 3.3000000 , 4.4000000 ]"',
+        "vectorStringProp": "\"[ 'one' , 'two' , 'three' ]\"",
+        "vectorStringProp2": "\"[ 'one' , 'two' , 'three' , 'four' ]\"",
+    }
+
+    alg_name = "CellIDWriter" if i < 2 else "Producer"
+    for prop, value in props_and_values.items():
+        print(prop, value)
+        if configuration_metadata[f"{alg_name}.{prop} "] != f" {value}":
+            raise RuntimeError(
+                f"Property {prop} has value {configuration_metadata[f'CellIDWriter.{prop} ']}, expected {value}"
+            )

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
@@ -62,6 +62,32 @@ private:
   Gaudi::Property<std::string> m_metadataString{this, "MetadataString", "hello", "Example of a string"};
   Gaudi::Property<std::vector<int>> m_PDGValues{
       this, "PDGValues", {1, 2, 3, 4}, "Values of the PDG used for the particles"};
+
+  // Some properties for the configuration metadata
+  Gaudi::Property<int>                m_intProp{this, "intProp", 42, "An integer property"};
+  Gaudi::Property<int>                m_intProp2{this, "intProp2", 42, "An integer property"};
+  Gaudi::Property<float>              m_floatProp{this, "floatProp", 3.14, "A float property"};
+  Gaudi::Property<float>              m_floatProp2{this, "floatProp2", 3.14, "A float property"};
+  Gaudi::Property<double>             m_doubleProp{this, "doubleProp", 3.14, "A double property"};
+  Gaudi::Property<double>             m_doubleProp2{this, "doubleProp2", 3.14, "A double property"};
+  Gaudi::Property<std::string>        m_stringProp{this, "stringProp", "Hello", "A string property"};
+  Gaudi::Property<std::string>        m_stringProp2{this, "stringProp2", "Hello", "A string property"};
+  Gaudi::Property<std::vector<int>>   m_vectorIntProp{this, "vectorIntProp", {1, 2, 3}, "A vector of integers"};
+  Gaudi::Property<std::vector<int>>   m_vectorIntProp2{this, "vectorIntProp2", {1, 2, 3}, "A vector of integers"};
+  Gaudi::Property<std::vector<float>> m_vectorFloatProp{this, "vectorFloatProp", {1.1, 2.2, 3.3}, "A vector of floats"};
+  Gaudi::Property<std::vector<float>> m_vectorFloatProp2{
+      this, "vectorFloatProp2", {1.1, 2.2, 3.3}, "A vector of floats"};
+  Gaudi::Property<std::vector<double>> m_vectorDoubleProp{
+      this, "vectorDoubleProp", {1.1, 2.2, 3.3}, "A vector of doubles"};
+  Gaudi::Property<std::vector<double>> m_vectorDoubleProp2{
+      this, "vectorDoubleProp2", {1.1, 2.2, 3.3}, "A vector of doubles"};
+  Gaudi::Property<std::vector<std::string>> m_vectorStringProp{
+      this, "vectorStringProp", {"one", "two", "three"}, "A vector of strings"};
+  Gaudi::Property<std::vector<std::string>> m_vectorStringProp2{
+      this,
+      "vectorStringProp2",
+      {"one", "two", "three"},
+  };
 };
 
 DECLARE_COMPONENT(ExampleFunctionalMetadataProducer)

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -54,5 +54,31 @@ private:
                                                                                    Gaudi::DataHandle::Writer, this};
   MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
                                              Gaudi::DataHandle::Writer};
+
+  // Some properties for the configuration metadata
+  Gaudi::Property<int>                m_intProp{this, "intProp", 42, "An integer property"};
+  Gaudi::Property<int>                m_intProp2{this, "intProp2", 42, "An integer property"};
+  Gaudi::Property<float>              m_floatProp{this, "floatProp", 3.14, "A float property"};
+  Gaudi::Property<float>              m_floatProp2{this, "floatProp2", 3.14, "A float property"};
+  Gaudi::Property<double>             m_doubleProp{this, "doubleProp", 3.14, "A double property"};
+  Gaudi::Property<double>             m_doubleProp2{this, "doubleProp2", 3.14, "A double property"};
+  Gaudi::Property<std::string>        m_stringProp{this, "stringProp", "Hello", "A string property"};
+  Gaudi::Property<std::string>        m_stringProp2{this, "stringProp2", "Hello", "A string property"};
+  Gaudi::Property<std::vector<int>>   m_vectorIntProp{this, "vectorIntProp", {1, 2, 3}, "A vector of integers"};
+  Gaudi::Property<std::vector<int>>   m_vectorIntProp2{this, "vectorIntProp2", {1, 2, 3}, "A vector of integers"};
+  Gaudi::Property<std::vector<float>> m_vectorFloatProp{this, "vectorFloatProp", {1.1, 2.2, 3.3}, "A vector of floats"};
+  Gaudi::Property<std::vector<float>> m_vectorFloatProp2{
+      this, "vectorFloatProp2", {1.1, 2.2, 3.3}, "A vector of floats"};
+  Gaudi::Property<std::vector<double>> m_vectorDoubleProp{
+      this, "vectorDoubleProp", {1.1, 2.2, 3.3}, "A vector of doubles"};
+  Gaudi::Property<std::vector<double>> m_vectorDoubleProp2{
+      this, "vectorDoubleProp2", {1.1, 2.2, 3.3}, "A vector of doubles"};
+  Gaudi::Property<std::vector<std::string>> m_vectorStringProp{
+      this, "vectorStringProp", {"one", "two", "three"}, "A vector of strings"};
+  Gaudi::Property<std::vector<std::string>> m_vectorStringProp2{
+      this,
+      "vectorStringProp2",
+      {"one", "two", "three"},
+  };
 };
 #endif /* K4FWCORE_K4FWCORETEST_CELLID_WRITER */


### PR DESCRIPTION
to avoid having properties that are deleted because other algorithms are wrapped in a Sequencer and this Sequencer is deleted before `finalize()` is called for Writer. This is what is happening in https://github.com/key4hep/k4FWCore/issues/260 and why some variables are not being saved. The service that is used to get the properties holds references to the properties, so if the properties are deleted, well, apparently they will become empty. This doesn't happen when not using the IOSvc and Writer because the algorithms are not wrapped inside a Sequencer, so the `finalize()` sequence is called for all of them before any of them is deleted.


BEGINRELEASENOTES
- Write the configuration_metadata at initialize() in the Writer, to avoid having properties that are deleted because other algorithms are wrapped in a Sequencer and this Sequencer is deleted before `finalize()` is called for Writer.
- Add tests for different combinations of old/functional algorithms and using PodioOutput or IOSvc and Writer.

ENDRELEASENOTES