### PR TITLE
Writer: Ignore objects that are not collections

### DIFF
--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -262,8 +262,8 @@ public:
           // This can happen for objects that are not collections like in the
           // MarlinWrapper for converter maps or a LCEvent, or, in general,
           // anything else
-          warning() << "Object in the store with name " << coll
-                    << " does not look like a collection so it can not be written to the output file" << endmsg;
+          info() << "Object in the store with name " << coll
+                 << " does not look like a collection so it can not be written to the output file" << endmsg;
           m_collectionsToSave.erase(std::remove(m_collectionsToSave.begin(), m_collectionsToSave.end(), coll),
                                     m_collectionsToSave.end());
           m_collectionsToAdd.erase(std::remove(m_collectionsToAdd.begin(), m_collectionsToAdd.end(), coll),

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -257,8 +257,15 @@ public:
         // Check the case when the data has been produced using the old DataHandle
         const auto old_collection = dynamic_cast<DataWrapperBase*>(storeCollection);
         if (!old_collection) {
-          error() << "Failed to cast collection " << coll << endmsg;
-          return;
+          // This can happen for objects that are not collections like in the
+          // MarlinWrapper for converter maps or a LCEvent, or, in general,
+          // anything else
+          warning() << "Object in the store with name " << coll
+                    << " does not look like a collection so it can not be written to the output file" << endmsg;
+          m_collectionsToSave.erase(std::remove(m_collectionsToSave.begin(), m_collectionsToSave.end(), coll),
+                                    m_collectionsToSave.end());
+          m_collectionsToAdd.erase(std::remove(m_collectionsToAdd.begin(), m_collectionsToAdd.end(), coll),
+                                   m_collectionsToAdd.end());
         } else {
           std::unique_ptr<podio::CollectionBase> uptr(
               const_cast<podio::CollectionBase*>(old_collection->collectionBase()));

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -21,8 +21,10 @@
 #include "GaudiKernel/AnyDataWrapper.h"
 #include "GaudiKernel/IDataManagerSvc.h"
 #include "GaudiKernel/IDataProviderSvc.h"
+#include "GaudiKernel/IHiveWhiteBoard.h"
 #include "GaudiKernel/SmartDataPtr.h"
 #include "GaudiKernel/StatusCode.h"
+
 #include "podio/Frame.h"
 
 #include "IIOSvc.h"
@@ -31,7 +33,7 @@
 #include "k4FWCore/FunctionalUtils.h"
 #include "k4FWCore/IMetadataSvc.h"
 
-#include <GaudiKernel/IHiveWhiteBoard.h>
+#include <algorithm>
 #include <memory>
 #include <utility>
 

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -156,7 +156,7 @@ public:
       error() << "Failed to retrieve object leaves" << endmsg;
       return;
     }
-    for (auto& pReg : leaves) {
+    for (const auto& pReg : leaves) {
       if (pReg->name() == k4FWCore::frameLocation) {
         continue;
       }
@@ -190,7 +190,7 @@ public:
     // This is the case when we are reading from a file
     // Putting it into a unique_ptr will make sure it's deleted
     if (code.isSuccess()) {
-      auto sc = m_dataSvc->unregisterObject(p);
+      const auto sc = m_dataSvc->unregisterObject(p);
       if (!sc.isSuccess()) {
         error() << "Failed to unregister object" << endmsg;
         return;
@@ -221,7 +221,7 @@ public:
     // Remove the collections owned by a Frame (if any) so that they are not
     // deleted by the store (and later deleted by the Frame, triggering a double
     // delete)
-    for (auto& coll : frameCollections) {
+    for (const auto& coll : frameCollections) {
       DataObject* storeCollection;
       if (m_dataSvc->retrieveObject("/Event/" + coll, storeCollection).isFailure()) {
         error() << "Failed to retrieve collection " << coll << endmsg;
@@ -233,12 +233,12 @@ public:
         return;
       }
       // We still have to delete the AnyDataWrapper to avoid a leak
-      auto storePtr = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(storeCollection);
-      storePtr->getData().release();
+      const auto storePtr = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(storeCollection);
+      [[maybe_unused]] auto releasedPtr = storePtr->getData().release();
       delete storePtr;
     }
 
-    for (auto& coll : m_collectionsToAdd) {
+    for (const auto& coll : m_collectionsToAdd) {
       DataObject* storeCollection;
       if (m_dataSvc->retrieveObject("/Event/" + coll, storeCollection).isFailure()) {
         error() << "Failed to retrieve collection " << coll << endmsg;

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -232,6 +232,8 @@ public:
       }
       // We still have to delete the AnyDataWrapper to avoid a leak
       const auto storePtr = dynamic_cast<AnyDataWrapper<std::unique_ptr<podio::CollectionBase>>*>(storeCollection);
+      // Assign to an unused variable to silence the warning about not using the
+      // result of release()
       [[maybe_unused]] auto releasedPtr = storePtr->getData().release();
       delete storePtr;
     }

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -188,6 +188,7 @@ set_tests_properties(FunctionalWrongImport PROPERTIES PASS_REGULAR_EXPRESSION "I
 add_test_with_env(FunctionalReadNthEvent options/ExampleFunctionalReadNthEvent.py PROPERTIES DEPENDS FunctionalProducer ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalProducerRNTuple options/ExampleFunctionalProducerRNTuple.py ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalTTreeToRNTuple options/ExampleFunctionalTTreeToRNTuple.py PROPERTIES DEPENDS FunctionalProducer ADD_TO_CHECK_FILES)
+add_test_with_env(GaudiFunctional options/ExampleGaudiFunctional.py)
 
 
 # The following is done to make the tests work without installing the files in

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -188,7 +188,7 @@ set_tests_properties(FunctionalWrongImport PROPERTIES PASS_REGULAR_EXPRESSION "I
 add_test_with_env(FunctionalReadNthEvent options/ExampleFunctionalReadNthEvent.py PROPERTIES DEPENDS FunctionalProducer ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalProducerRNTuple options/ExampleFunctionalProducerRNTuple.py ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalTTreeToRNTuple options/ExampleFunctionalTTreeToRNTuple.py PROPERTIES DEPENDS FunctionalProducer ADD_TO_CHECK_FILES)
-add_test_with_env(GaudiFunctional options/ExampleGaudiFunctional.py)
+add_test_with_env(GaudiFunctional options/ExampleGaudiFunctional.py PROPERTIES DEPENDS FunctionalProducer ADD_TO_CHECK_FILES)
 
 
 # The following is done to make the tests work without installing the files in

--- a/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
+++ b/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
@@ -21,19 +21,23 @@
 # data
 
 from Gaudi.Configuration import INFO
-from Configurables import ExampleGaudiFunctionalProducer
+from Configurables import ExampleGaudiFunctionalProducer, ExampleFunctionalTransformer
 from Configurables import EventDataSvc
 from k4FWCore import ApplicationMgr, IOSvc
 
 svc = IOSvc("IOSvc")
-svc.Output = "functional_transformer.root"
+svc.Input = "functional_producer.root"
+svc.Output = "gaudi_functional.root"
 
-producer = ExampleGaudiFunctionalProducer("Producer", OutputCollectionName="Output")
+gaudi_producer = ExampleGaudiFunctionalProducer("GaudiProducer", OutputCollectionName="Output")
+transformer = ExampleFunctionalTransformer(
+    "Transformer", InputCollection=["MCParticles"], OutputCollection=["NewMCParticles"]
+)
 
 mgr = ApplicationMgr(
-    TopAlg=[producer],
+    TopAlg=[gaudi_producer, transformer],
     EvtSel="NONE",
-    EvtMax=3,
+    EvtMax=-1,
     ExtSvc=[EventDataSvc("EventDataSvc")],
     OutputLevel=INFO,
 )

--- a/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
+++ b/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
@@ -28,9 +28,7 @@ from k4FWCore import ApplicationMgr, IOSvc
 svc = IOSvc("IOSvc")
 svc.Output = "functional_transformer.root"
 
-producer = ExampleGaudiFunctionalProducer(
-    "Producer", OutputCollectionName="Output"
-)
+producer = ExampleGaudiFunctionalProducer("Producer", OutputCollectionName="Output")
 
 mgr = ApplicationMgr(
     TopAlg=[producer],

--- a/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
+++ b/test/k4FWCoreTest/options/ExampleGaudiFunctional.py
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an example reading from a file and using a producer to create new
+# data
+
+from Gaudi.Configuration import INFO
+from Configurables import ExampleGaudiFunctionalProducer
+from Configurables import EventDataSvc
+from k4FWCore import ApplicationMgr, IOSvc
+
+svc = IOSvc("IOSvc")
+svc.Output = "functional_transformer.root"
+
+producer = ExampleGaudiFunctionalProducer(
+    "Producer", OutputCollectionName="Output"
+)
+
+mgr = ApplicationMgr(
+    TopAlg=[producer],
+    EvtSel="NONE",
+    EvtMax=3,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -70,6 +70,7 @@ def check_metadata(filename, expected_metadata):
 
 
 check_collections("functional_transformer.root", ["MCParticles", "NewMCParticles"])
+check_collections("gaudi_functional.root", ["MCParticles", "NewMCParticles"])
 check_collections("functional_transformer_cli.root", ["MCParticles", "NewMCParticles"])
 check_collections(
     "functional_transformer_multiple.root",

--- a/test/k4FWCoreTest/src/components/ExampleGaudiFunctionalProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleGaudiFunctionalProducer.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Gaudi/Functional/Producer.h"
+
+#include <string>
+
+using BaseClass_t = Gaudi::Functional::Traits::BaseClass_t<Gaudi::Algorithm>;
+
+struct ExampleGaudiFunctionalProducer final : Gaudi::Functional::Producer<int(), BaseClass_t> {
+  // The pair in KeyValues can be changed from python and it corresponds
+  // to the name of the output collection
+  ExampleGaudiFunctionalProducer(const std::string& name, ISvcLocator* svcLoc)
+    : Producer(name, svcLoc, KeyValue{"OutputCollectionName", "OutputCollection"}) {}
+
+  // This is the function that will be called to produce the data
+  int operator()() const override {
+    return 3;
+  }
+};
+
+DECLARE_COMPONENT(ExampleGaudiFunctionalProducer)

--- a/test/k4FWCoreTest/src/components/ExampleGaudiFunctionalProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleGaudiFunctionalProducer.cpp
@@ -27,12 +27,10 @@ struct ExampleGaudiFunctionalProducer final : Gaudi::Functional::Producer<int(),
   // The pair in KeyValues can be changed from python and it corresponds
   // to the name of the output collection
   ExampleGaudiFunctionalProducer(const std::string& name, ISvcLocator* svcLoc)
-    : Producer(name, svcLoc, KeyValue{"OutputCollectionName", "OutputCollection"}) {}
+      : Producer(name, svcLoc, KeyValue{"OutputCollectionName", "OutputCollection"}) {}
 
   // This is the function that will be called to produce the data
-  int operator()() const override {
-    return 3;
-  }
+  int operator()() const override { return 3; }
 };
 
 DECLARE_COMPONENT(ExampleGaudiFunctionalProducer)


### PR DESCRIPTION
Currently if the Writer finds something that is not a collection either produced by the functional algorithms or the data handle-based algorithms it will not write any frames. After this PR, a warning will appear once and they will simply be ignored.

BEGINRELEASENOTES
- Writer: Ignore objects that are not collections in the store and write an output Frame
  - Add `const` where possible
  - Add `[[maybe_unused]]` to avoid a warning about not using the result of a `.release()` (the warning is correct in most cases, in this case it's the Gaudi store who owns it).
  - Remove some code in the Writer that is not necessary.

ENDRELEASENOTES