### PR TITLE
Improve the documentation about extending the parser for k4run

### DIFF
--- a/doc/k4run-args.md
+++ b/doc/k4run-args.md
@@ -18,7 +18,8 @@ limitations under the License.
 -->
 # Adding custom arguments to `k4run`
 
-It is possible to extend `k4run` with custom arguments from a steering file using `k4FWCore.parseArgs`.
+It is possible to extend `k4run` with custom arguments from a steering file
+using `k4FWCore.parseArgs`.
 
 Example:
 
@@ -32,4 +33,9 @@ if my_opts.trackingOnly:
     # only run track reconstruction
 ```
 
-Behind the scenes parser is just a normal instance of pythons [`argparse.ArgumentParser`](https://docs.python.org/3/library/argparse.html), please refer to its documentation for usage details. The only important thing to keep in mind is to always use `parse_known_args()` instead of `parse_args()` so that the normal `k4run` arguments keep working.
+Behind the scenes `parser` is just a normal instance of python's
+[`argparse.ArgumentParser`](https://docs.python.org/3/library/argparse.html),
+please refer to its documentation for usage details. Use `parse_known_args()`
+instead of `parse_args()` so that the normal `k4run` arguments keep working. The
+`[0]` is necessary because the added arguments will be in the first element of
+the tuple returned from `parse_known_args`.

--- a/doc/k4run-args.md
+++ b/doc/k4run-args.md
@@ -38,7 +38,7 @@ if my_opts.trackingOnly:
 The example steering file can then be executed as follows:
 
 ```
-k4run example_steering_file.py --trackingOnly --some-other-args 
+k4run example_steering_file.py --trackingOnly --some-other-args
 ```
 
 Behind the scenes `parser` is just a normal instance of python's

--- a/doc/k4run-args.md
+++ b/doc/k4run-args.md
@@ -16,6 +16,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
+
+
 # Adding custom arguments to `k4run`
 
 It is possible to extend `k4run` with custom arguments from a steering file
@@ -31,6 +33,12 @@ my_opts = parser.parse_known_args()[0]
 # later
 if my_opts.trackingOnly:
     # only run track reconstruction
+```
+
+The example steering file can then be executed as follows:
+
+```
+k4run example_steering_file.py --trackingOnly --some-other-args 
 ```
 
 Behind the scenes `parser` is just a normal instance of python's


### PR DESCRIPTION
BEGINRELEASENOTES
- Improve the documentation about extending the parser for k4run

ENDRELEASENOTES

Some minor syntax changes and a comment about the `[0]` that I typically forget when writing from memory.