### PR TITLE
Remove the unnecessary r-value reference

### DIFF
--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -45,6 +45,6 @@ StatusCode MetadataSvc::finalize() { return Service::finalize(); }
 
 const podio::Frame* MetadataSvc::getFrame() const { return m_frame.get(); }
 podio::Frame*       MetadataSvc::getFrame() { return m_frame.get(); }
-void MetadataSvc::setFrame(podio::Frame&& frame) { m_frame = std::make_unique<podio::Frame>(std::move(frame)); }
+void MetadataSvc::setFrame(podio::Frame frame) { m_frame = std::make_unique<podio::Frame>(std::move(frame)); }
 
 DECLARE_COMPONENT(MetadataSvc)

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -42,7 +42,7 @@ protected:
 
   const podio::Frame* getFrame() const override;
   podio::Frame*       getFrame() override;
-  void                setFrame(podio::Frame&& frame) override;
+  void                setFrame(podio::Frame frame) override;
 };
 
 #endif

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -29,7 +29,7 @@ class IMetadataSvc : virtual public IInterface {
 public:
   DeclareInterfaceID(IMetadataSvc, 1, 0);
 
-  virtual void setFrame(podio::Frame&& frame) = 0;
+  virtual void setFrame(podio::Frame frame) = 0;
 
   template <typename T> void put(const std::string& name, const T& obj) {
     if (!getFrame()) {


### PR DESCRIPTION
The frame is move only in any case


BEGINRELEASENOTES
- Remove an unnecessary r-value reference qualifier for sinking the metadata Frame into the `MetadataSvc`.

ENDRELEASENOTES

Mainly because I saw [this lightning talk](https://www.youtube.com/watch?v=iH86aQrzIKU) yesterday and this seems to be a case where it's unnecessary.

(We have this in quite a few places, where the *move-only* property of our types already ensures that a `std::move` on the calling site is necessary if not using a temporary)
