### PR TITLE
Add the possibility to set `edm4hep::utils::ParticleIDMeta` via the `IMetadataSvc`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
 find_package(podio 1.0.1 REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
+find_package(fmt REQUIRED)
 
 include(cmake/Key4hepConfig.cmake)
 
@@ -45,7 +46,6 @@ add_subdirectory(k4FWCore)
 add_subdirectory(k4Interface)
 add_subdirectory(python)
 if(BUILD_TESTING)
-  find_package(fmt REQUIRED)
   add_subdirectory(test/k4FWCoreTest)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(k4FWCore)
 add_subdirectory(k4Interface)
 add_subdirectory(python)
 if(BUILD_TESTING)
+  find_package(fmt REQUIRED)
   add_subdirectory(test/k4FWCoreTest)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ print(my_opts[0].foo)
 
 * EDM4HEP
 
+* fmt
+
 ## Installation and downstream usage.
 
 k4FWCore is a CMake project. After setting up the dependencies (use for example `source /cvmfs/sw.hsf.org/key4hep/setup.sh`)

--- a/cmake/k4FWCoreConfig.cmake.in
+++ b/cmake/k4FWCoreConfig.cmake.in
@@ -22,6 +22,7 @@ find_dependency(podio @podio_VERSION@)
 find_dependency(Gaudi @Gaudi_VERSION@)
 find_dependency(EDM4HEP @EDM4HEP_VERSION@)
 find_dependency(ROOT @ROOT_VERSION@ COMPONENTS RIO Tree)
+find_dependency(fmt @fmt_VERSION@)
 
 if(NOT TARGET k4FWCore::k4FWCore)
   include("${CMAKE_CURRENT_LIST_DIR}/k4FWCoreTargets.cmake")

--- a/k4FWCore/CMakeLists.txt
+++ b/k4FWCore/CMakeLists.txt
@@ -31,7 +31,7 @@ gaudi_install(PYTHON)
 gaudi_add_library(k4FWCore
 		  SOURCES src/PodioDataSvc.cpp
               src/KeepDropSwitch.cpp
-                  LINK Gaudi::GaudiKernel podio::podioIO ROOT::Core ROOT::RIO ROOT::Tree
+                  LINK Gaudi::GaudiKernel podio::podioIO ROOT::Core ROOT::RIO ROOT::Tree EDM4HEP::utils
                   )
 target_include_directories(k4FWCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -21,6 +21,8 @@
 
 #include "GaudiKernel/IInterface.h"
 
+#include "edm4hep/utils/ParticleIDUtils.h"
+
 #include "podio/Frame.h"
 
 class IMetadataSvc : virtual public IInterface {
@@ -31,12 +33,7 @@ public:
 
   virtual void setFrame(podio::Frame frame) = 0;
 
-  template <typename T> void put(const std::string& name, const T& obj) {
-    if (!getFrame()) {
-      setFrame(podio::Frame{});
-    }
-    getFrame()->putParameter(name, obj);
-  }
+  template <typename T> void put(const std::string& name, const T& obj) { getFrameForWrite()->putParameter(name, obj); }
 
   template <typename T> std::optional<T> get(const std::string& name) const {
     const auto* frame = getFrame();
@@ -49,6 +46,31 @@ public:
 protected:
   virtual podio::Frame*       getFrame()       = 0;
   virtual const podio::Frame* getFrame() const = 0;
+
+private:
+  podio::Frame* getFrameForWrite() {
+    if (!getFrame()) {
+      setFrame(podio::Frame());
+    }
+    return getFrame();
+  }
 };
+
+template <>
+inline void IMetadataSvc::put<edm4hep::utils::ParticleIDMeta>(const std::string&                    collName,
+                                                              const edm4hep::utils::ParticleIDMeta& pidMetaInfo) {
+  edm4hep::utils::PIDHandler::setAlgoInfo(*getFrameForWrite(), collName, pidMetaInfo);
+}
+
+template <>
+inline std::optional<edm4hep::utils::ParticleIDMeta> IMetadataSvc::get<edm4hep::utils::ParticleIDMeta>(
+    const std::string& collName) const {
+  const auto* frame = getFrame();
+  if (!frame) {
+    return std::nullopt;
+  }
+
+  return edm4hep::utils::PIDHandler::getAlgoInfo(*frame, collName);
+}
 
 #endif

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -206,3 +206,10 @@ add_test_with_env(ParticleIDMetadataFramework options/ExampleParticleIDMetadata.
 add_custom_command(TARGET k4FWCoreTestPlugins POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                    ${PROJECT_SOURCE_DIR}/python/k4FWCore/ ${PROJECT_BINARY_DIR}/k4FWCore/genConfDir/k4FWCore)
+
+
+add_executable(check_ParticleIDOutputs src/check_ParticleIDOutputs.cpp)
+target_link_libraries(check_ParticleIDOutputs PRIVATE podio::podioIO EDM4HEP::edm4hep EDM4HEP::utils fmt::fmt)
+add_test(NAME check_ParticleIDOutputs COMMAND check_ParticleIDOutputs example_with_particleids.root)
+set_test_env(check_ParticleIDOutputs)
+set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetadataFramework)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -195,6 +195,8 @@ add_test_with_env(FunctionalProducerRNTuple options/ExampleFunctionalProducerRNT
 add_test_with_env(FunctionalTTreeToRNTuple options/ExampleFunctionalTTreeToRNTuple.py PROPERTIES FIXTURES_REQUIRED ProducerFile ADD_TO_CHECK_FILES)
 add_test_with_env(GaudiFunctional options/ExampleGaudiFunctional.py PROPERTIES FIXTURES_REQUIRED ProducerFile ADD_TO_CHECK_FILES)
 
+add_test_with_env(ParticleIDMetadataFramework options/ExampleParticleIDMetadata.py)
+
 
 # The following is done to make the tests work without installing the files in
 # the installation directory. The k4FWCore in the build directory is populated by

--- a/test/k4FWCoreTest/options/ExampleFunctionalConsumerRuntimeCollectionsMultiple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalConsumerRuntimeCollectionsMultiple.py
@@ -37,6 +37,7 @@ producer0 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits0"],
     OutputCollectionTrackerHits=["TrackerHits0"],
     OutputCollectionTracks=["Tracks0"],
+    OutputCollectionRecoParticles=["Recos0"],
     ExampleInt=5,
 )
 producer1 = ExampleFunctionalProducerMultiple(
@@ -47,6 +48,7 @@ producer1 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits1"],
     OutputCollectionTrackerHits=["TrackerHits1"],
     OutputCollectionTracks=["Tracks1"],
+    OutputCollectionRecoParticles=["Recos1"],
     ExampleInt=5,
 )
 producer2 = ExampleFunctionalProducerMultiple(
@@ -57,6 +59,7 @@ producer2 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits2"],
     OutputCollectionTrackerHits=["TrackerHits2"],
     OutputCollectionTracks=["Tracks2"],
+    OutputCollectionRecoParticles=["Recos2"],
     ExampleInt=5,
 )
 

--- a/test/k4FWCoreTest/options/ExampleFunctionalTransformerRuntimeCollectionsMultiple.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalTransformerRuntimeCollectionsMultiple.py
@@ -38,6 +38,7 @@ producer0 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits0"],
     OutputCollectionTrackerHits=["TrackerHits0"],
     OutputCollectionTracks=["Tracks0"],
+    OutputCollectionRecoParticles=["Recos0"],
     ExampleInt=5,
 )
 producer1 = ExampleFunctionalProducerMultiple(
@@ -48,6 +49,7 @@ producer1 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits1"],
     OutputCollectionTrackerHits=["TrackerHits1"],
     OutputCollectionTracks=["Tracks1"],
+    OutputCollectionRecoParticles=["Recos1"],
     ExampleInt=5,
 )
 producer2 = ExampleFunctionalProducerMultiple(
@@ -58,6 +60,7 @@ producer2 = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["SimTrackerHits2"],
     OutputCollectionTrackerHits=["TrackerHits2"],
     OutputCollectionTracks=["Tracks2"],
+    OutputCollectionRecoParticles=["Recos2"],
     ExampleInt=5,
 )
 

--- a/test/k4FWCoreTest/options/ExampleParticleIDMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleParticleIDMetadata.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Example showcasing how to use ParticleID related metadata"""
+
+from Gaudi.Configuration import INFO
+from Configurables import (
+    ExampleParticleIDProducer,
+    ExampleParticleIDConsumer,
+    ExampleFunctionalProducerMultiple,
+    EventDataSvc,
+)
+from k4FWCore import ApplicationMgr, IOSvc
+
+# NOTE: If you are not using the IOSvc (e.g. because you don't need I/O), make
+# sure to add the MetadataSvc to the ExtSvc as that is necessary to store /
+# retrieve the metadata for ParticleIDs
+iosvc = IOSvc()
+iosvc.Output = "example_with_particleids.root"
+iosvc.outputCommands = ["drop *", "keep RecoParticles*"]
+
+reco_producer = ExampleFunctionalProducerMultiple(
+    "RecoProducer", OutputCollectionRecoParticles=["RecoParticles"]
+)
+
+pid_producer1 = ExampleParticleIDProducer(
+    "PIDProducer1",
+    InputCollection=["RecoParticles"],
+    ParticleIDCollection=["RecoParticlesPIDs_1"],
+    PIDAlgoName="PIDAlgo1",
+    PIDParamNames=["single_param"],
+)
+
+pid_producer2 = ExampleParticleIDProducer(
+    "PIDProducer2",
+    InputCollection=["RecoParticles"],
+    ParticleIDCollection=["RecoParticlesPIDs_2"],
+    PIDAlgoName="PIDAlgo2",
+    PIDParamNames=["param_1", "param_2", "param_3"],
+)
+
+pid_consumer = ExampleParticleIDConsumer(
+    "PIDConsumer",
+    RecoParticleCollection=reco_producer.OutputCollectionRecoParticles,
+    # From first producer
+    ParticleIDCollection1=pid_producer1.ParticleIDCollection,
+    PIDAlgoName1=pid_producer1.PIDAlgoName,
+    PIDParamNames1=pid_producer1.PIDParamNames,
+    ParamName1="single_param",
+    # From second producer
+    ParticleIDCollection2=pid_producer2.ParticleIDCollection,
+    PIDAlgoName2=pid_producer2.PIDAlgoName,
+    PIDParamNames2=pid_producer2.PIDParamNames,
+    ParamName2="param_2",
+)
+
+ApplicationMgr(
+    TopAlg=[reco_producer, pid_producer1, pid_producer2, pid_consumer],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/options/runFunctionalMix.py
+++ b/test/k4FWCoreTest/options/runFunctionalMix.py
@@ -90,6 +90,7 @@ producer_functional = ExampleFunctionalProducerMultiple(
     OutputCollectionSimTrackerHits=["FunctionalSimTrackerHits"],
     OutputCollectionTrackerHits=["FunctionalTrackerHits"],
     OutputCollectionTracks=["FunctionalTracks"],
+    OutputCollectionRecoParticles=["FunctionalRecos"],
     ExampleInt=5,
 )
 

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -83,11 +83,19 @@ check_collections(
         "Tracks",
         "Counter",
         "NewMCParticles",
+        "RecoParticles",
     ],
 )
 check_collections(
     "functional_transformer_multiple_output_commands.root",
-    ["VectorFloat", "MCParticles1", "MCParticles2", "SimTrackerHits", "TrackerHits"],
+    [
+        "VectorFloat",
+        "MCParticles1",
+        "MCParticles2",
+        "SimTrackerHits",
+        "TrackerHits",
+        "RecoParticles",
+    ],
 )
 check_collections("/tmp/a/b/c/functional_producer.root", ["MCParticles"])
 check_collections(
@@ -104,6 +112,7 @@ check_collections(
         "TrackerHits",
         "Tracks",
         "NewMCParticles",
+        "RecoParticles",
     ],
 )
 
@@ -116,6 +125,7 @@ mix_collections = [
     "SimTrackerHits",
     "TrackerHits",
     "Tracks",
+    "RecoParticles",
     # Produced by functional
     "FunctionalVectorFloat",
     "FunctionalMCParticles",
@@ -123,6 +133,7 @@ mix_collections = [
     "FunctionalSimTrackerHits",
     "FunctionalTrackerHits",
     "FunctionalTracks",
+    "FunctionalRecos",
     # Produced by an old algorithm
     "OldAlgorithmMCParticles",
     "OldAlgorithmSimTrackerHits",

--- a/test/k4FWCoreTest/src/check_ParticleIDOutputs.cpp
+++ b/test/k4FWCoreTest/src/check_ParticleIDOutputs.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <edm4hep/ReconstructedParticleCollection.h>
 #include <edm4hep/utils/ParticleIDUtils.h>
 

--- a/test/k4FWCoreTest/src/check_ParticleIDOutputs.cpp
+++ b/test/k4FWCoreTest/src/check_ParticleIDOutputs.cpp
@@ -47,23 +47,33 @@ bool checkAlgoMetadata(const edm4hep::utils::ParticleIDMeta& pidMeta, const std:
   return true;
 }
 
+// Test configuration (this needs to match the settings in
+// options/ExampleParticleIDMetadata.py)
+constexpr auto                 pidCollectionName1 = "RecoParticlesPIDs_1";
+constexpr auto                 pidCollectionName2 = "RecoParticlesPIDs_2";
+constexpr auto                 pidAlgo1           = "PIDAlgo1";
+constexpr auto                 pidAlgo2           = "PIDAlgo2";
+constexpr auto                 pidParam1          = "single_param";
+constexpr auto                 pidParam2          = "param_2";
+const std::vector<std::string> paramNames1        = {"single_param"};
+const std::vector<std::string> paramNames2        = {"param_1", "param_2", "param_3"};
+
 int main(int, char* argv[]) {
   auto       reader   = podio::makeReader(argv[1]);
   const auto metadata = reader.readFrame(podio::Category::Metadata, 0);
 
-  const auto pidMeta1 = edm4hep::utils::PIDHandler::getAlgoInfo(metadata, "RecoParticlesPIDs_1").value();
-  const auto pidMeta2 = edm4hep::utils::PIDHandler::getAlgoInfo(metadata, "RecoParticlesPIDs_2").value();
+  const auto pidMeta1 = edm4hep::utils::PIDHandler::getAlgoInfo(metadata, pidCollectionName1).value();
+  const auto pidMeta2 = edm4hep::utils::PIDHandler::getAlgoInfo(metadata, pidCollectionName2).value();
 
-  if (!checkAlgoMetadata(pidMeta1, "PIDAlgo1", {"single_param"}) ||
-      !checkAlgoMetadata(pidMeta2, "PIDAlgo2", {"param_1", "param_2", "param_3"})) {
+  if (!checkAlgoMetadata(pidMeta1, pidAlgo1, paramNames1) || !checkAlgoMetadata(pidMeta2, pidAlgo2, paramNames2)) {
     return 1;
   }
 
-  const auto paramIndex1 = edm4hep::utils::getParamIndex(pidMeta1, "single_param").value_or(-1);
-  const auto paramIndex2 = edm4hep::utils::getParamIndex(pidMeta2, "param_2").value_or(-1);
+  const auto paramIndex1 = edm4hep::utils::getParamIndex(pidMeta1, pidParam1).value_or(-1);
+  const auto paramIndex2 = edm4hep::utils::getParamIndex(pidMeta2, pidParam2).value_or(-1);
   if (paramIndex1 < 0 || paramIndex2 < 0) {
-    fmt::print("Could not get a parameter index for 'single_param' (got {}) or 'param_2' (got {})\n", paramIndex1,
-               paramIndex2);
+    fmt::print("Could not get a parameter index for '{}' (got {}) or '{}' (got {})\n", pidParam1, paramIndex1,
+               pidParam2, paramIndex2);
   }
 
   const auto event      = reader.readEvent(0);

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerMultiple.cpp
@@ -22,6 +22,7 @@
 #include "k4FWCore/Producer.h"
 
 #include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackCollection.h"
 #include "edm4hep/TrackerHit3DCollection.h"
@@ -33,19 +34,21 @@
 
 using retType =
     std::tuple<podio::UserDataCollection<float>, edm4hep::MCParticleCollection, edm4hep::MCParticleCollection,
-               edm4hep::SimTrackerHitCollection, edm4hep::TrackerHit3DCollection, edm4hep::TrackCollection>;
+               edm4hep::SimTrackerHitCollection, edm4hep::TrackerHit3DCollection, edm4hep::TrackCollection,
+               edm4hep::ReconstructedParticleCollection>;
 
 struct ExampleFunctionalProducerMultiple final : k4FWCore::Producer<retType()> {
   // The pairs in KeyValue can be changed from python and they correspond
   // to the names of the output collections
   ExampleFunctionalProducerMultiple(const std::string& name, ISvcLocator* svcLoc)
-      : Producer(name, svcLoc, {},
-                 {KeyValues("OutputCollectionFloat", {"VectorFloat"}),
-                  KeyValues("OutputCollectionParticles1", {"MCParticles1"}),
-                  KeyValues("OutputCollectionParticles2", {"MCParticles2"}),
-                  KeyValues("OutputCollectionSimTrackerHits", {"SimTrackerHits"}),
-                  KeyValues("OutputCollectionTrackerHits", {"TrackerHits"}),
-                  KeyValues("OutputCollectionTracks", {"Tracks"})}) {}
+      : Producer(
+            name, svcLoc, {},
+            {KeyValues("OutputCollectionFloat", {"VectorFloat"}),
+             KeyValues("OutputCollectionParticles1", {"MCParticles1"}),
+             KeyValues("OutputCollectionParticles2", {"MCParticles2"}),
+             KeyValues("OutputCollectionSimTrackerHits", {"SimTrackerHits"}),
+             KeyValues("OutputCollectionTrackerHits", {"TrackerHits"}), KeyValues("OutputCollectionTracks", {"Tracks"}),
+             KeyValues("OutputCollectionRecoParticles", {"RecoParticles"})}) {}
 
   // This is the function that will be called to produce the data
   retType operator()() const override {
@@ -84,8 +87,14 @@ struct ExampleFunctionalProducerMultiple final : k4FWCore::Producer<retType()> {
     track.addToTrackerHits(trackerHit);
     track.addToTracks(track2);
 
+    auto recos = edm4hep::ReconstructedParticleCollection();
+    for (int i = 1; i < 5; ++i) {
+      auto reco = recos.create();
+      reco.setPDG(i);
+    }
+
     return std::make_tuple(std::move(floatVector), std::move(particles), edm4hep::MCParticleCollection(),
-                           std::move(simTrackerHits), std::move(trackerHits), std::move(tracks));
+                           std::move(simTrackerHits), std::move(trackerHits), std::move(tracks), std::move(recos));
   }
 
 private:

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
@@ -96,7 +96,7 @@ struct ExampleParticleIDConsumer final
 
     m_paramIndex1 = edm4hep::utils::getParamIndex(m_pidMeta1, m_paramOfInterest1.value()).value_or(-1);
     m_paramIndex2 = edm4hep::utils::getParamIndex(m_pidMeta2, m_paramOfInterest2.value()).value_or(-1);
-    if (m_paramIndex1 < 0 || m_paramIndex2 < 0) {
+    if (m_paramIndex1 == -1 || m_paramIndex2 == -1) {
       error() << fmt::format("Could not get a parameter index for {} (got {}) or {} (got {})",
                              m_paramOfInterest1.value(), m_paramIndex1, m_paramOfInterest2.value(), m_paramIndex2)
               << endmsg;

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
@@ -108,7 +108,8 @@ struct ExampleParticleIDConsumer final
   void operator()(const edm4hep::ParticleIDCollection& pidColl1, const edm4hep::ParticleIDCollection& pidColl2,
                   const edm4hep::ReconstructedParticleCollection& recos) const override {
     auto pidHandler = edm4hep::utils::PIDHandler::from(pidColl1, pidColl2);
-    pidHandler.addMetaInfos(m_pidMeta1, m_pidMeta2);
+    pidHandler.addMetaInfo(m_pidMeta1);
+    pidHandler.addMetaInfo(m_pidMeta2);
 
     for (const auto r : recos) {
       auto pids = pidHandler.getPIDs(r);

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <edm4hep/ReconstructedParticleCollection.h>
+#include "k4FWCore/Consumer.h"
+#include "k4FWCore/MetadataUtils.h"
+
+#include "edm4hep/ParticleIDCollection.h"
+#include "edm4hep/utils/ParticleIDUtils.h"
+
+#include <Gaudi/Property.h>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+
+struct ExampleParticleIDConsumer final
+    : k4FWCore::Consumer<void(const edm4hep::ParticleIDCollection&, const edm4hep::ParticleIDCollection&,
+                              const edm4hep::ReconstructedParticleCollection&)> {
+  ExampleParticleIDConsumer(const std::string& name, ISvcLocator* svcLoc)
+      : Consumer(name, svcLoc,
+                 {KeyValues("ParticleIDCollection1", {"PIDs1"}), KeyValues("ParticleIDCollection2", {"PIDs2"}),
+                  KeyValues("RecoParticleCollection", {"recos"})}) {}
+
+  bool checkAlgoMetadata(const edm4hep::utils::ParticleIDMeta& pidMeta, const Gaudi::Property<std::string>& algoName,
+                         const Gaudi::Property<std::vector<std::string>>& paramNames) const {
+    if (pidMeta.algoName != algoName) {
+      fatal() << fmt::format(
+                     "The PID algorithm name from metadata does not match the expected one from the properties: "
+                     "(expected {}, actual {})",
+                     algoName.value(), pidMeta.algoName)
+              << endmsg;
+      return false;
+    }
+
+    if (!std::ranges::equal(pidMeta.paramNames, paramNames)) {
+      fatal() << fmt::format(
+                     "The PID parameter names retrieved from metadata does not match the expected ones from the "
+                     "properties: (expected {}, actual {})",
+                     paramNames.value(), pidMeta.paramNames)
+              << endmsg;
+      return false;
+    }
+
+    return true;
+  }
+
+  void checkPIDForAlgo(const edm4hep::utils::PIDHandler& pidHandler, const edm4hep::ReconstructedParticle& reco,
+                       const edm4hep::utils::ParticleIDMeta& pidMeta, const int paramIndex) const {
+    auto maybePID = pidHandler.getPID(reco, pidMeta.algoType());
+    if (!maybePID) {
+      throw std::runtime_error(
+          std::format("Could net retrieve the {} PID object for reco particle {}", pidMeta.algoName, reco.id().index));
+    }
+    auto pid      = maybePID.value();
+    auto paramVal = pid.getParameters()[paramIndex];
+
+    // As set in the producer
+    if (paramVal != paramIndex * 0.5f) {
+      throw std::runtime_error(
+          fmt::format("Could not retrieve the correct parameter value for param {} (expected {}, actual {})",
+                      pidMeta.paramNames[paramIndex], paramIndex * 0.5f, paramVal));
+    }
+  }
+
+  StatusCode initialize() final {
+    m_pidMeta1 =
+        k4FWCore::getParameter<edm4hep::utils::ParticleIDMeta>(inputLocations("ParticleIDCollection1")[0]).value();
+
+    m_pidMeta2 =
+        k4FWCore::getParameter<edm4hep::utils::ParticleIDMeta>(inputLocations("ParticleIDCollection2")[0]).value();
+
+    if (!checkAlgoMetadata(m_pidMeta1, m_pidAlgoName1, m_pidParamNames1) ||
+        !checkAlgoMetadata(m_pidMeta2, m_pidAlgoName2, m_pidParamNames2)) {
+      return StatusCode::FAILURE;
+    }
+
+    m_paramIndex1 = edm4hep::utils::getParamIndex(m_pidMeta1, m_paramOfInterest1.value()).value_or(-1);
+    m_paramIndex2 = edm4hep::utils::getParamIndex(m_pidMeta2, m_paramOfInterest2.value()).value_or(-1);
+    if (m_paramIndex1 < 0 || m_paramIndex2 < 0) {
+      error() << fmt::format("Could not get a parameter index for {} (got {}) or {} (got {})",
+                             m_paramOfInterest1.value(), m_paramIndex1, m_paramOfInterest2.value(), m_paramIndex2)
+              << std::endl;
+    }
+
+    return StatusCode::SUCCESS;
+  }
+
+  void operator()(const edm4hep::ParticleIDCollection& pidColl1, const edm4hep::ParticleIDCollection& pidColl2,
+                  const edm4hep::ReconstructedParticleCollection& recos) const {
+    auto pidHandler = edm4hep::utils::PIDHandler::from(pidColl1, pidColl2);
+    pidHandler.addMetaInfos(m_pidMeta1, m_pidMeta2);
+
+    for (const auto r : recos) {
+      auto pids = pidHandler.getPIDs(r);
+      if (pids.size() != 2) {
+        throw std::runtime_error(
+            std::format("Could not get 2 ParticleID objects related to reco particle {}", r.id().index));
+      }
+
+      checkPIDForAlgo(pidHandler, r, m_pidMeta1, m_paramIndex1);
+      checkPIDForAlgo(pidHandler, r, m_pidMeta2, m_paramIndex2);
+    }
+  }
+
+private:
+  edm4hep::utils::ParticleIDMeta m_pidMeta1{};
+  edm4hep::utils::ParticleIDMeta m_pidMeta2{};
+
+  int m_paramIndex1{};
+  int m_paramIndex2{};
+
+  Gaudi::Property<std::string> m_pidAlgoName1{
+      this, "PIDAlgoName1", "fancyPID",
+      "The name of the first ParticleID algorithm that should be used for the metadata"};
+  Gaudi::Property<std::vector<std::string>> m_pidParamNames1{
+      this,
+      "PIDParamNames1",
+      {"p1", "p2", "p3"},
+      "The names of the parameters of the first PID algorithm that will be stored into metadata"};
+  Gaudi::Property<std::string> m_paramOfInterest1{this, "ParamName1", "p1",
+                                                  "The name of the parameter that should be checked"};
+  Gaudi::Property<std::string> m_pidAlgoName2{
+      this, "PIDAlgoName2", "fancyPID",
+      "The name of the second ParticleID algorithm that should be used for the metadata"};
+  Gaudi::Property<std::vector<std::string>> m_pidParamNames2{
+      this,
+      "PIDParamNames2",
+      {"p1", "p2", "p3"},
+      "The names of the parameters of the second PID algorithm that will be stored into metadata"};
+  Gaudi::Property<std::string> m_paramOfInterest2{this, "ParamName2", "p2",
+                                                  "The name of the parameter that should be checked"};
+};
+
+DECLARE_COMPONENT(ExampleParticleIDConsumer);

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
@@ -106,7 +106,7 @@ struct ExampleParticleIDConsumer final
   }
 
   void operator()(const edm4hep::ParticleIDCollection& pidColl1, const edm4hep::ParticleIDCollection& pidColl2,
-                  const edm4hep::ReconstructedParticleCollection& recos) const {
+                  const edm4hep::ReconstructedParticleCollection& recos) const override {
     auto pidHandler = edm4hep::utils::PIDHandler::from(pidColl1, pidColl2);
     pidHandler.addMetaInfos(m_pidMeta1, m_pidMeta2);
 

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDConsumer.cpp
@@ -69,7 +69,7 @@ struct ExampleParticleIDConsumer final
     auto maybePID = pidHandler.getPID(reco, pidMeta.algoType());
     if (!maybePID) {
       throw std::runtime_error(
-          std::format("Could net retrieve the {} PID object for reco particle {}", pidMeta.algoName, reco.id().index));
+          fmt::format("Could net retrieve the {} PID object for reco particle {}", pidMeta.algoName, reco.id().index));
     }
     auto pid      = maybePID.value();
     auto paramVal = pid.getParameters()[paramIndex];
@@ -99,7 +99,7 @@ struct ExampleParticleIDConsumer final
     if (m_paramIndex1 < 0 || m_paramIndex2 < 0) {
       error() << fmt::format("Could not get a parameter index for {} (got {}) or {} (got {})",
                              m_paramOfInterest1.value(), m_paramIndex1, m_paramOfInterest2.value(), m_paramIndex2)
-              << std::endl;
+              << endmsg;
     }
 
     return StatusCode::SUCCESS;
@@ -114,7 +114,7 @@ struct ExampleParticleIDConsumer final
       auto pids = pidHandler.getPIDs(r);
       if (pids.size() != 2) {
         throw std::runtime_error(
-            std::format("Could not get 2 ParticleID objects related to reco particle {}", r.id().index));
+            fmt::format("Could not get 2 ParticleID objects related to reco particle {}", r.id().index));
       }
 
       checkPIDForAlgo(pidHandler, r, m_pidMeta1, m_paramIndex1);

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDProducer.cpp
@@ -41,9 +41,9 @@ struct ExampleParticleIDProducer final
     return StatusCode::SUCCESS;
   }
 
-  edm4hep::ParticleIDCollection operator()(const edm4hep::ReconstructedParticleCollection& recos) const {
+  edm4hep::ParticleIDCollection operator()(const edm4hep::ReconstructedParticleCollection& recos) const override {
     auto pidColl = edm4hep::ParticleIDCollection{};
-    for (const auto r : recos) {
+    for (const auto& r : recos) {
       auto pid = pidColl.create();
       pid.setAlgorithmType(m_pidMeta.algoType());
       pid.setPDG(r.getPDG() - 10);

--- a/test/k4FWCoreTest/src/components/ExampleParticleIDProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleParticleIDProducer.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "k4FWCore/MetadataUtils.h"
+#include "k4FWCore/Transformer.h"
+
+#include "edm4hep/ParticleIDCollection.h"
+#include "edm4hep/ReconstructedParticleCollection.h"
+#include "edm4hep/utils/ParticleIDUtils.h"
+
+#include "Gaudi/Property.h"
+
+#include <string>
+
+struct ExampleParticleIDProducer final
+    : k4FWCore::Transformer<edm4hep::ParticleIDCollection(const edm4hep::ReconstructedParticleCollection&)> {
+  ExampleParticleIDProducer(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc, {KeyValues("InputCollection", {"RecoParticles"})},
+                    KeyValues("ParticleIDCollection", {"reco_PIDs"})) {}
+
+  StatusCode initialize() final {
+    m_pidMeta            = {m_pidAlgoName, m_pidParamNames};
+    std::string collname = outputLocations("ParticleIDCollection")[0];
+    k4FWCore::putParameter(collname, m_pidMeta);
+    return StatusCode::SUCCESS;
+  }
+
+  edm4hep::ParticleIDCollection operator()(const edm4hep::ReconstructedParticleCollection& recos) const {
+    auto pidColl = edm4hep::ParticleIDCollection{};
+    for (const auto r : recos) {
+      auto pid = pidColl.create();
+      pid.setAlgorithmType(m_pidMeta.algoType());
+      pid.setPDG(r.getPDG() - 10);
+      pid.setParticle(r);
+      for (size_t i = 0; i < m_pidMeta.paramNames.size(); ++i) {
+        pid.addToParameters(i * 0.5f);
+      }
+    }
+
+    return pidColl;
+  }
+
+private:
+  Gaudi::Property<std::string> m_pidAlgoName{
+      this, "PIDAlgoName", "fancyPID", "The name of the ParticleID algorithm that should be used for the metadata"};
+  Gaudi::Property<std::vector<std::string>> m_pidParamNames{
+      this,
+      "PIDParamNames",
+      {"p1", "p2", "p3"},
+      "The names of the parameters of the PID algorithm that will be stored into metadata"};
+
+  edm4hep::utils::ParticleIDMeta m_pidMeta{};
+};
+
+DECLARE_COMPONENT(ExampleParticleIDProducer);


### PR DESCRIPTION
BEGINRELEASENOTES
- Make it possible to use `edm4hep::utils::ParticleIDMeta` with the `MetadataSvc`
  - Add template specializations for `get` and `put` that defer to the corresponding utility calls in EDM4hep
  - Add tests to ensure that metadata is indeed usable this way with the utilities in EDM4hep  

ENDRELEASENOTES

This would be option 1 sketched out in #272 

- [x] Small test that checks that metadata is also usable outside of framework
- [x] Needs https://github.com/key4hep/EDM4hep/pull/395