### PR TITLE
Make sure Functional algorithms check types during conversion

### DIFF
--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -137,15 +137,15 @@ namespace k4FWCore {
           auto inputMap     = std::vector<const EDM4hepType*>();
           for (auto& handle : std::get<Index>(handles)) {
             podio::CollectionBase* in = handle.get()->get();
-            auto*                  typedIn = dynamic_cast<EDM4hepType*>(in);
+            auto*                  typedIn = dynamic_cast<const EDM4hepType*>(in);
             if (typedIn) {
-              inputMap.push_back(static_cast<EDM4hepType*>(typedIn));
+              inputMap.push_back(typedIn);
             } else {
               throw GaudiException(
                   thisClass->name(),
                   fmt::format(
                       "Failed to cast collection {} to the required type {}, the type of the collection is {}",
-                      handle.objKey(), typeid(EDM4hepType).name(), in ? in->getTypeName() : "[undetermined]"),
+                        handle.objKey(), EDM4hepType::typeName, in ? in->getTypeName() : "[undetermined]"),
                   StatusCode::FAILURE);
             }
           }

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -161,7 +161,8 @@ namespace k4FWCore {
               throw GaudiException(
                   thisClass->name(),
                   fmt::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
-                              std::get<Index>(handles)[0].objKey(), EDM4hepType::typeName, in->getTypeName()),
+                              std::get<Index>(handles)[0].objKey(), EDM4hepType::typeName,
+                              in ? in->getTypeName() : "[undetermined]"),
                   StatusCode::FAILURE);
             }
           } catch (GaudiException& e) {

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -136,16 +136,15 @@ namespace k4FWCore {
           using EDM4hepType = std::remove_cv_t<std::remove_pointer_t<typename TupleType::value_type>>;
           auto inputMap     = std::vector<const EDM4hepType*>();
           for (auto& handle : std::get<Index>(handles)) {
-            podio::CollectionBase* in = handle.get()->get();
+            podio::CollectionBase* in      = handle.get()->get();
             auto*                  typedIn = dynamic_cast<const EDM4hepType*>(in);
             if (typedIn) {
               inputMap.push_back(typedIn);
             } else {
               throw GaudiException(
                   thisClass->name(),
-                  fmt::format(
-                      "Failed to cast collection {} to the required type {}, the type of the collection is {}",
-                        handle.objKey(), EDM4hepType::typeName, in ? in->getTypeName() : "[undetermined]"),
+                  fmt::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
+                              handle.objKey(), typeid(EDM4hepType).name(), in ? in->getTypeName() : "[undetermined]"),
                   StatusCode::FAILURE);
             }
           }
@@ -154,7 +153,7 @@ namespace k4FWCore {
           // Bare EDM4hep type, without pointers or const
           using EDM4hepType = std::remove_cv_t<std::remove_pointer_t<TupleType>>;
           try {
-            podio::CollectionBase* in   = std::get<Index>(handles)[0].get()->get();
+            podio::CollectionBase* in      = std::get<Index>(handles)[0].get()->get();
             auto*                  typedIn = dynamic_cast<EDM4hepType*>(in);
             if (typedIn) {
               std::get<Index>(inputTuple) = typedIn;

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -34,6 +34,8 @@
 
 // #include "GaudiKernel/CommonMessaging.h"
 
+#include <fmt/format.h>
+
 #include <memory>
 #include <tuple>
 #include <type_traits>

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -212,4 +212,4 @@ target_link_libraries(check_ParticleIDOutputs PRIVATE podio::podioIO EDM4HEP::ed
 add_test(NAME check_ParticleIDOutputs COMMAND check_ParticleIDOutputs example_with_particleids.root)
 set_test_env(check_ParticleIDOutputs)
 set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetadataFramework)
-add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py)
+add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -214,4 +214,4 @@ set_test_env(check_ParticleIDOutputs)
 set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetadataFramework)
 add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")
 
-add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")
+add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles1 to the required type")

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -213,3 +213,5 @@ add_test(NAME check_ParticleIDOutputs COMMAND check_ParticleIDOutputs example_wi
 set_test_env(check_ParticleIDOutputs)
 set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetadataFramework)
 add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")
+
+add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -207,9 +207,9 @@ add_custom_command(TARGET k4FWCoreTestPlugins POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                    ${PROJECT_SOURCE_DIR}/python/k4FWCore/ ${PROJECT_BINARY_DIR}/k4FWCore/genConfDir/k4FWCore)
 
-
 add_executable(check_ParticleIDOutputs src/check_ParticleIDOutputs.cpp)
 target_link_libraries(check_ParticleIDOutputs PRIVATE podio::podioIO EDM4HEP::edm4hep EDM4HEP::utils fmt::fmt)
 add_test(NAME check_ParticleIDOutputs COMMAND check_ParticleIDOutputs example_with_particleids.root)
 set_test_env(check_ParticleIDOutputs)
 set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetadataFramework)
+add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py)

--- a/test/k4FWCoreTest/options/TypeMisMatchDemo.py
+++ b/test/k4FWCoreTest/options/TypeMisMatchDemo.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+from Gaudi.Configuration import INFO, DEBUG
+from Configurables import ExampleFunctionalProducer, TypeMisMatchDemo, EventDataSvc
+
+from k4FWCore import ApplicationMgr
+
+producer = ExampleFunctionalProducer("Producer", OutputCollection=["MCParticles"])
+
+mismatch = TypeMisMatchDemo(InputCollection=["MCParticles"], OutputLevel=DEBUG)
+
+ApplicationMgr(
+    TopAlg=[producer, mismatch],
+    EvtSel="NONE",
+    EvtMax=1,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/options/TypeMisMatchDemo.py
+++ b/test/k4FWCoreTest/options/TypeMisMatchDemo.py
@@ -1,4 +1,22 @@
 #!/usr/bin/env python3
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 from Gaudi.Configuration import INFO, DEBUG
 from Configurables import ExampleFunctionalProducer, TypeMisMatchDemo, EventDataSvc

--- a/test/k4FWCoreTest/options/TypeMisMatchDemoMultiple.py
+++ b/test/k4FWCoreTest/options/TypeMisMatchDemoMultiple.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+
+#!/usr/bin/env python3
+
+from Gaudi.Configuration import INFO, DEBUG
+from Configurables import ExampleFunctionalProducerMultiple, TypeMisMatchDemoMultiple, EventDataSvc
+
+from k4FWCore import ApplicationMgr
+
+producer = ExampleFunctionalProducerMultiple("Producer")
+
+mismatch = TypeMisMatchDemoMultiple(InputCollections=["Tracks", "MCParticles1"], OutputLevel=DEBUG)
+
+ApplicationMgr(
+    TopAlg=[producer, mismatch],
+    EvtSel="NONE",
+    EvtMax=1,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/options/TypeMisMatchDemoMultiple.py
+++ b/test/k4FWCoreTest/options/TypeMisMatchDemoMultiple.py
@@ -1,7 +1,22 @@
 #!/usr/bin/env python3
-
-
-#!/usr/bin/env python3
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 from Gaudi.Configuration import INFO, DEBUG
 from Configurables import ExampleFunctionalProducerMultiple, TypeMisMatchDemoMultiple, EventDataSvc

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -175,8 +175,18 @@ check_collections(
 podio_reader = podio.root_io.Reader("functional_merged_collections.root")
 frames = podio_reader.get("events")
 ev = frames[0]
-if len(ev.get("NewMCParticles")) != 4:
-    raise RuntimeError(f"Expected 4 NewMCParticles but got {len(ev.get('NewMCParticles'))}")
+new_mcs = ev.get("NewMCParticles")
+merged_mc_colls = [ev.get(f"MCParticles{i}") for i in range(1, 4)]
+merged_mcs = [mcc[i] for mcc in merged_mc_colls for i in range(len(mcc))]
+if len(new_mcs) != len(merged_mcs):
+    raise RuntimeError(f"Expected {len(merged_mcs)} NewMCParticles but got {len(new_mcs)}")
+
+for new_mc, orig_mc in zip(new_mcs, merged_mcs):
+    if new_mc.id() != orig_mc.id():
+        raise RuntimeError(
+            f"merged mcs do not match, expected [{new_mc.id().collectionID}, {new_mc.id().index}], actual [{orig_mc.id().collectionID}, {orig_mc.id().index}]"
+        )
+
 
 check_collections("functional_metadata.root", ["MCParticles"])
 

--- a/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
+++ b/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
@@ -1,0 +1,26 @@
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/TrackCollection.h"
+
+#include "k4FWCore/Transformer.h"
+
+#include <Gaudi/Property.h>
+#include <GaudiKernel/ISvcLocator.h>
+
+#include <string>
+
+struct TypeMisMatchDemo final : k4FWCore::Transformer<edm4hep::MCParticleCollection(const edm4hep::TrackCollection&)> {
+  TypeMisMatchDemo(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc, {KeyValues("InputCollection", {"MCParticles"})},
+                    {KeyValues("OutputCollection", {"MCParticles2"})}) {}
+
+  edm4hep::MCParticleCollection operator()(const edm4hep::TrackCollection& inputs) const final {
+    debug() << inputs.size() << " type = " << inputs.getTypeName() << endmsg;
+    auto track = inputs[0];
+    // The next line goes boom
+    debug() << track.getTrackerHits().size() << endmsg;
+
+    return edm4hep::MCParticleCollection{};
+  }
+};
+
+DECLARE_COMPONENT(TypeMisMatchDemo)

--- a/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
+++ b/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
@@ -24,3 +24,23 @@ struct TypeMisMatchDemo final : k4FWCore::Transformer<edm4hep::MCParticleCollect
 };
 
 DECLARE_COMPONENT(TypeMisMatchDemo)
+
+struct TypeMisMatchDemoMultiple final
+    : k4FWCore::Transformer<edm4hep::MCParticleCollection(const std::vector<const edm4hep::TrackCollection*>&)> {
+  TypeMisMatchDemoMultiple(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc, {KeyValues("InputCollections", {"MCParticles1", "MCParticles2"})},
+                    {KeyValues("OutputCollection", {"OutputMCParticles"})}) {}
+
+  edm4hep::MCParticleCollection operator()(const std::vector<const edm4hep::TrackCollection*>& input) const final {
+    for (const auto& trackColl : input) {
+      debug() << "collection size: " << trackColl->size() << " type = " << trackColl->getTypeName() << endmsg;
+      auto track = (*trackColl)[0];
+      // The next line goes boom
+      debug() << track.getTrackerHits().size() << endmsg;
+    }
+
+    return edm4hep::MCParticleCollection{};
+  }
+};
+
+DECLARE_COMPONENT(TypeMisMatchDemoMultiple)

--- a/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
+++ b/test/k4FWCoreTest/src/components/TypeMisMatchDemo.cpp
@@ -1,3 +1,21 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/TrackCollection.h"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure that the internal casts that happen for functional algorithms do not silently cast to wrong types.

ENDRELEASENOTES

Fixes #274 

- [x] which other `static_cast`s need these checks?
- [x] More tests, e.g. at least one algorithm where the branch with the vector of inputs and multiple inputs is triggered.