### PR TITLE
Use typeid to allow compiling functional algorithms that use Links

### DIFF
--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -157,7 +157,7 @@ namespace k4FWCore {
               if (!wrp) {
                 throw GaudiException(thisClass->name(),
                                      "Failed to cast collection " + std::get<Index>(handles)[0].objKey() +
-                                         " to the requested type " + EDM4hepType::typeName,
+                                         " to the requested type " + typeid(EDM4hepType).name(),
                                      StatusCode::FAILURE);
               }
               std::get<Index>(inputTuple) = const_cast<EDM4hepType*>(wrp->getData());


### PR DESCRIPTION
BEGINRELEASENOTES
- Use typeid to allow compiling functional algorithms that use Links

ENDRELEASENOTES

I'll follow up on this another day, but for now this is necessary to make the nightlies build.