### PR TITLE
Fix compilation warning about comparing integers with different signs

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -58,7 +58,7 @@ struct ExampleEventHeaderConsumer final : k4FWCore::Consumer<void(const edm4hep:
   Gaudi::Property<int>              m_runNumber{this, "runNumber", 0, "The expected run number"};
   Gaudi::Property<int>              m_eventNumberOffset{this, "eventNumberOffset", 0,
                                            "The event number offset where events will start counting from"};
-  mutable std::atomic<std::int32_t> m_evtCounter{0};
+  mutable std::atomic<std::uint32_t> m_evtCounter{0};
 };
 
 DECLARE_COMPONENT(ExampleEventHeaderConsumer)


### PR DESCRIPTION
Related to https://github.com/key4hep/EDM4hep/pull/398

BEGINRELEASENOTES
- Fix compilation warning about comparing integers with different signs, related to https://github.com/key4hep/EDM4hep/pull/398

ENDRELEASENOTES