### PR TITLE
Fix algorithm properties related to `eventNumber` and `runNumber` to deduce their type

### DIFF
--- a/k4FWCore/components/EventHeaderCreator.cpp
+++ b/k4FWCore/components/EventHeaderCreator.cpp
@@ -28,7 +28,7 @@ EventHeaderCreator::EventHeaderCreator(const std::string& name, ISvcLocator* svc
 
 StatusCode EventHeaderCreator::execute(const EventContext& ctx) const {
   auto eventNumber = ctx.evt();
-  debug() << "Filling EventHeader with runNumber " << int(m_runNumber) << " and eventNumber "
+  debug() << "Filling EventHeader with runNumber " << m_runNumber.value() << " and eventNumber "
           << eventNumber + m_eventNumberOffset << endmsg;
   auto headers = m_headerCol.createAndPut();
   auto header  = headers->create();

--- a/k4FWCore/components/EventHeaderCreator.h
+++ b/k4FWCore/components/EventHeaderCreator.h
@@ -20,9 +20,9 @@
 #define K4FWCORE_EVENTHEADERCREATOR
 
 #include <edm4hep/Constants.h>
+#include <edm4hep/EventHeaderCollection.h>
 #include "Gaudi/Algorithm.h"
 #include "k4FWCore/DataHandle.h"
-
 /***
  * Algorithm that creates an EventHeader collection and fills it with eventNumber and runNumber
  */
@@ -38,12 +38,16 @@ public:
   StatusCode execute(const EventContext&) const override;
 
 private:
+  // Since the type of the runNumber and eventNumber changed recently in EDM4hep, deduce their type
+  // instead of hardcoding it to avoid warnings
   // Run number value (fixed for the entire job, to be set by the job submitter)
-  Gaudi::Property<int> m_runNumber{this, "runNumber", 1, "Run number value"};
+  Gaudi::Property<decltype(std::declval<edm4hep::EventHeader>().getRunNumber())> m_runNumber{this, "runNumber", 1,
+                                                                                             "Run number value"};
   // Event number offset, use it if you want two separated jobs with the same run number
-  Gaudi::Property<int> m_eventNumberOffset{
+  Gaudi::Property<decltype(std::declval<edm4hep::EventHeader>().getEventNumber())> m_eventNumberOffset{
       this, "eventNumberOffset", 0,
       "Event number offset, eventNumber will be filled with 'event_index + eventNumberOffset'"};
+
   // datahandle for the EventHeader
   mutable DataHandle<edm4hep::EventHeaderCollection> m_headerCol{edm4hep::labels::EventHeader,
                                                                  Gaudi::DataHandle::Writer, this};

--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -55,11 +55,12 @@ struct ExampleEventHeaderConsumer final : k4FWCore::Consumer<void(const edm4hep:
     }
   }
 
-  Gaudi::Property<int> m_runNumber{this, "runNumber", 0, "The expected run number"};
-  Gaudi::Property<int> m_eventNumberOffset{this, "eventNumberOffset", 0,
-                                           "The event number offset where events will start counting from"};
-  // Since the type of the runNumber changed recently in EDM4hep, use its type
+  // Since the type of the runNumber and eventNumber changed recently in EDM4hep, deduce their type
   // instead of hardcoding it to avoid warnings
+  Gaudi::Property<decltype(std::declval<edm4hep::EventHeader>().getEventNumber())> m_runNumber{
+      this, "runNumber", 0, "The expected run number"};
+  Gaudi::Property<decltype(std::declval<edm4hep::EventHeader>().getEventNumber())> m_eventNumberOffset{
+      this, "eventNumberOffset", 0, "The event number offset where events will start counting from"};
   mutable std::atomic<decltype(std::declval<edm4hep::EventHeader>().getRunNumber())> m_evtCounter{0};
 };
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix algorithm properties related to `eventNumber` and `runNumber` to deduce their type

ENDRELEASENOTES

This is follow-up to #278, that changes types of remaining properties that are related to `eventNumer` and `runNumber`.
This is mostly to be consistent and avoid implicit conversions or a potential footgun with adding negative event-offset to unsigned event number