### PR TITLE
Add support for reading collections stored as DataWrapper<podio::CollectionBase> in functional algorithms

### DIFF
--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -175,10 +175,9 @@ namespace k4FWCore {
               DataObject*       p;
               IDataProviderSvc* svc = thisClass->evtSvc();
               svc->retrieveObject("/Event/" + std::get<Index>(handles)[0].objKey(), p).ignore();
-              // This is how Gaudi::Algorithms will save collections through the DataHandle
+              // This is how Gaudi::Algorithms saves collections through the DataHandle
               const auto* wrp = dynamic_cast<const DataWrapper<EDM4hepType>*>(p);
-              // This is how the Marlin wrapper will save collections when converting
-              // from LCIO to EDM4hep
+              // This is how the Marlin wrapper saves collections when converting from LCIO to EDM4hep
               const auto* marlinWrp = dynamic_cast<const DataWrapper<podio::CollectionBase>*>(p);
               if (!wrp && !marlinWrp) {
                 throw GaudiException(thisClass->name(),

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -175,14 +175,23 @@ namespace k4FWCore {
               DataObject*       p;
               IDataProviderSvc* svc = thisClass->evtSvc();
               svc->retrieveObject("/Event/" + std::get<Index>(handles)[0].objKey(), p).ignore();
+              // This is how Gaudi::Algorithms will save collections through the DataHandle
               const auto* wrp = dynamic_cast<const DataWrapper<EDM4hepType>*>(p);
-              if (!wrp) {
+              // This is how the Marlin wrapper will save collections when converting
+              // from LCIO to EDM4hep
+              const auto* marlinWrp = dynamic_cast<const DataWrapper<podio::CollectionBase>*>(p);
+              if (!wrp && !marlinWrp) {
                 throw GaudiException(thisClass->name(),
                                      "Failed to cast collection " + std::get<Index>(handles)[0].objKey() +
                                          " to the requested type " + typeid(EDM4hepType).name(),
                                      StatusCode::FAILURE);
               }
-              std::get<Index>(inputTuple) = const_cast<EDM4hepType*>(wrp->getData());
+              if (wrp) {
+                std::get<Index>(inputTuple) = const_cast<EDM4hepType*>(wrp->getData());
+              } else {
+                std::get<Index>(inputTuple) =
+                    dynamic_cast<EDM4hepType*>(const_cast<podio::CollectionBase*>(marlinWrp->getData()));
+              }
             } else {
               throw e;
             }

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -215,3 +215,4 @@ set_tests_properties(check_ParticleIDOutputs PROPERTIES DEPENDS ParticleIDMetada
 add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles to the required type")
 
 add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles1 to the required type")
+add_test_with_env(ReadMarlinWrapperCollection options/readMarlinWrapperCollection.py)

--- a/test/k4FWCoreTest/options/readMarlinWrapperCollection.py
+++ b/test/k4FWCoreTest/options/readMarlinWrapperCollection.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This is an example producing, transforming and consuming data in memory
+
+from Gaudi.Configuration import INFO
+from Configurables import ExampleFunctionalConsumer, k4FWCoreTest_CreateMarlinWrapperCollection
+from k4FWCore import ApplicationMgr
+from Configurables import EventDataSvc
+
+producer = k4FWCoreTest_CreateMarlinWrapperCollection("Producer")
+consumer = ExampleFunctionalConsumer(
+    "Consumer",
+    InputCollection=["MCParticles"],
+    Offset=0,
+)
+
+ApplicationMgr(
+    TopAlg=[producer, consumer],
+    EvtSel="NONE",
+    EvtMax=10,
+    ExtSvc=[EventDataSvc("EventDataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateMarlinWrapperCollection.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateMarlinWrapperCollection.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "k4FWCoreTest_CreateMarlinWrapperCollection.h"
+
+#include "edm4hep/MCParticleCollection.h"
+#include "podio/CollectionBase.h"
+
+#include "k4FWCore/DataWrapper.h"
+
+k4FWCoreTest_CreateMarlinWrapperCollection::k4FWCoreTest_CreateMarlinWrapperCollection(const std::string& aName,
+                                                                                       ISvcLocator*       aSvcLoc)
+    : Gaudi::Algorithm(aName, aSvcLoc) {}
+
+StatusCode k4FWCoreTest_CreateMarlinWrapperCollection::initialize() {
+  m_eventDataSvc = service("EventDataSvc");
+  if (!m_eventDataSvc) {
+    error() << "Could not retrieve EventDataSvc" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  return StatusCode::SUCCESS;
+}
+
+StatusCode k4FWCoreTest_CreateMarlinWrapperCollection::execute(const EventContext&) const {
+  auto wrapper = new DataWrapper<podio::CollectionBase>();
+  auto coll    = new edm4hep::MCParticleCollection();
+
+  coll->create(1, 2, 3, 4.f, 5.f, 6.f);
+  // We can also set the fields of the particle manually
+  auto particle = coll->create(2, 3, 4, 5.f, 6.f, 7.f);
+  particle.setPDG(2);
+  particle.setGeneratorStatus(3);
+  particle.setSimulatorStatus(4);
+  particle.setCharge(5.f);
+  particle.setTime(6.f);
+  particle.setMass(7.f);
+
+  wrapper->setData(coll);
+  auto sc = m_eventDataSvc->registerObject("/Event/" + m_outputCollectionName, wrapper);
+  if (!sc) {
+    error() << "Could not register collection " << endmsg;
+  }
+
+  return StatusCode::SUCCESS;
+}
+
+DECLARE_COMPONENT(k4FWCoreTest_CreateMarlinWrapperCollection)

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateMarlinWrapperCollection.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateMarlinWrapperCollection.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef K4FWCORE_K4FWCORETEST_CREATEMARLINWRAPPERCOLLECTION
+#define K4FWCORE_K4FWCORETEST_CREATEMARLINWRAPPERCOLLECTION
+
+#include "Gaudi/Algorithm.h"
+#include "GaudiKernel/IDataProviderSvc.h"
+
+/** @class k4FWCoreTest_CreateMarlinWrapperCollection
+ *  Produce a collection the same way that the Marlin wrapper does.
+ */
+class k4FWCoreTest_CreateMarlinWrapperCollection : public Gaudi::Algorithm {
+public:
+  explicit k4FWCoreTest_CreateMarlinWrapperCollection(const std::string&, ISvcLocator*);
+  /**  Execute.
+   *   @return status code
+   */
+  StatusCode initialize() override;
+  StatusCode execute(const EventContext&) const final;
+
+private:
+  SmartIF<IDataProviderSvc>    m_eventDataSvc;
+  Gaudi::Property<std::string> m_outputCollectionName{this, "OutputCollection", "MCParticles",
+                                                      "Name of the output collection"};
+};
+#endif /* K4FWCORE_K4FWCORETEST_CREATEMARLINWRAPPERCOLLECTION */


### PR DESCRIPTION
This is needed for https://github.com/key4hep/k4MarlinWrapper/pull/216, because the collections that the Marlin wrapper produces are stored as `DataWrapper<podio::CollectionBase>` (see https://github.com/key4hep/k4MarlinWrapper/blob/main/k4MarlinWrapper/src/components/Lcio2EDM4hep.cpp#L83), which we don't use anywhere else.

BEGINRELEASENOTES
- Make functional algorithms read `DataWrapper<podio::CollectionBase>` 
- Add a test producing a collection in a `DataWrapper<podio::CollectionBase>` and reading it in a functional algorithm

ENDRELEASENOTES