### PR TITLE
Use typeid instead of EDM4hep::typeName

### DIFF
--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -161,7 +161,7 @@ namespace k4FWCore {
               throw GaudiException(
                   thisClass->name(),
                   fmt::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
-                              std::get<Index>(handles)[0].objKey(), EDM4hepType::typeName,
+                              std::get<Index>(handles)[0].objKey(), typeid(EDM4hepType).name(),
                               in ? in->getTypeName() : "[undetermined]"),
                   StatusCode::FAILURE);
             }


### PR DESCRIPTION
Introduced in https://github.com/key4hep/k4FWCore/pull/275, same as https://github.com/key4hep/k4FWCore/pull/277, see https://github.com/AIDASoft/podio/issues/731.

BEGINRELEASENOTES
- Use typeid instead of `EDM4hep::typeName` since not every EDM4hep type has `::typeName`.

ENDRELEASENOTES

I forgot to change it in the PR, I even thought about it :(
I'm in the process of adding some tests with Links, it seems we have none and we are blind to this from k4FWCore.