### PR TITLE
Use the same integer widths in `UniqueIDGenSvc` as in `EventHeader`

### DIFF
--- a/k4FWCore/components/UniqueIDGenSvc.h
+++ b/k4FWCore/components/UniqueIDGenSvc.h
@@ -38,7 +38,7 @@ public:
   using seed_t = uint64_t;
 
   UniqueIDGenSvc(const std::string& name, ISvcLocator* svcLoc);
-  size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const override;
+  size_t getUniqueID(const event_num_t evt_num, const run_num_t run_num, const std::string& name) const override;
 
 private:
   Gaudi::Property<seed_t>                           m_seed{this, "Seed", {123456789}};

--- a/k4FWCore/components/UniqueIDGenSvc.h
+++ b/k4FWCore/components/UniqueIDGenSvc.h
@@ -35,11 +35,13 @@
  */
 class UniqueIDGenSvc : public extends<Service, IUniqueIDGenSvc> {
 public:
+  using seed_t = uint64_t;
+
   UniqueIDGenSvc(const std::string& name, ISvcLocator* svcLoc);
-  size_t getUniqueID(uint32_t evt_num, uint32_t run_num, const std::string& name) const override;
+  size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const override;
 
 private:
-  Gaudi::Property<uint64_t>                         m_seed{this, "Seed", {123456789}};
+  Gaudi::Property<seed_t>                           m_seed{this, "Seed", {123456789}};
   mutable std::unordered_set<size_t, std::identity> m_uniqueIDs;
   mutable std::mutex                                m_mutex;
   Gaudi::Property<bool>                             m_throwIfDuplicate{this, "ThrowIfDuplicate", {true}};

--- a/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
+++ b/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
@@ -32,8 +32,10 @@
  */
 
 struct GAUDI_API IUniqueIDGenSvc : extend_interfaces<IInterface> {
+  using event_num_t = uint32_t;
+  using run_num_t   = uint32_t;
   DeclareInterfaceID(IUniqueIDGenSvc, 2, 0);
-  virtual size_t getUniqueID(uint32_t evt_num, uint32_t run_num, const std::string& name) const = 0;
+  virtual size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const = 0;
 };
 
 #endif

--- a/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
+++ b/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
@@ -38,6 +38,9 @@ struct GAUDI_API IUniqueIDGenSvc : extend_interfaces<IInterface> {
   using run_num_t   = decltype(std::declval<edm4hep::EventHeader>().getRunNumber());
   DeclareInterfaceID(IUniqueIDGenSvc, 2, 0);
   virtual size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const = 0;
+  size_t         getUniqueID(const edm4hep::EventHeader& evt_header, const std::string& name) const {
+    return getUniqueID(evt_header.getEventNumber(), evt_header.getRunNumber(), name);
+  }
 };
 
 #endif

--- a/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
+++ b/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
@@ -19,7 +19,7 @@
 #ifndef FWCORE_IUNIQUEIDGENSVC_H
 #define FWCORE_IUNIQUEIDGENSVC_H
 
-#include "edm4hep/EventHeader.h"
+#include "edm4hep/EventHeaderCollection.h"
 
 #include <cstddef>
 #include <string>
@@ -40,6 +40,10 @@ struct GAUDI_API IUniqueIDGenSvc : extend_interfaces<IInterface> {
   virtual size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const = 0;
   size_t         getUniqueID(const edm4hep::EventHeader& evt_header, const std::string& name) const {
     return getUniqueID(evt_header.getEventNumber(), evt_header.getRunNumber(), name);
+  }
+  // calculate a unique id from name and the first element of collection
+  size_t getUniqueID(const edm4hep::EventHeaderCollection& evt_headers, const std::string& name) const {
+    return getUniqueID(evt_headers.at(0), name);
   }
 };
 

--- a/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
+++ b/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
@@ -19,7 +19,9 @@
 #ifndef FWCORE_IUNIQUEIDGENSVC_H
 #define FWCORE_IUNIQUEIDGENSVC_H
 
-#include <cstdint>
+#include "edm4hep/EventHeader.h"
+
+#include <cstddef>
 #include <string>
 
 #include <GaudiKernel/IInterface.h>
@@ -32,8 +34,8 @@
  */
 
 struct GAUDI_API IUniqueIDGenSvc : extend_interfaces<IInterface> {
-  using event_num_t = uint32_t;
-  using run_num_t   = uint32_t;
+  using event_num_t = decltype(std::declval<edm4hep::EventHeader>().getEventNumber());
+  using run_num_t   = decltype(std::declval<edm4hep::EventHeader>().getRunNumber());
   DeclareInterfaceID(IUniqueIDGenSvc, 2, 0);
   virtual size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const = 0;
 };

--- a/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
+++ b/k4Interface/include/k4Interface/IUniqueIDGenSvc.h
@@ -37,7 +37,7 @@ struct GAUDI_API IUniqueIDGenSvc : extend_interfaces<IInterface> {
   using event_num_t = decltype(std::declval<edm4hep::EventHeader>().getEventNumber());
   using run_num_t   = decltype(std::declval<edm4hep::EventHeader>().getRunNumber());
   DeclareInterfaceID(IUniqueIDGenSvc, 2, 0);
-  virtual size_t getUniqueID(event_num_t evt_num, run_num_t run_num, const std::string& name) const = 0;
+  virtual size_t getUniqueID(const event_num_t evt_num, const run_num_t run_num, const std::string& name) const = 0;
   size_t         getUniqueID(const edm4hep::EventHeader& evt_header, const std::string& name) const {
     return getUniqueID(evt_header.getEventNumber(), evt_header.getRunNumber(), name);
   }

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 #include "TestUniqueIDGenSvc.h"
-
 #include <cstdint>
+#include "edm4hep/MutableEventHeader.h"
 
 DECLARE_COMPONENT(TestUniqueIDGenSvc)
 
@@ -40,12 +40,14 @@ StatusCode TestUniqueIDGenSvc::initialize() {
 // For the second event, the service throws when trying to get the same ID twice
 StatusCode TestUniqueIDGenSvc::execute(const EventContext&) const {
   ++m_counter;
-  uint32_t    evt_num = 4;
-  uint32_t    run_num = 3 + m_counter.sum();
-  std::string name    = "Some algorithm name";
+  auto evt_header = edm4hep::MutableEventHeader{};
+  evt_header.setEventNumber(4);
+  evt_header.setRunNumber(3 + m_counter.sum());
+  std::string name = "Some algorithm name";
 
-  auto uid       = m_service->getUniqueID(evt_num, run_num, name);
-  auto uid_again = m_service->getUniqueID(evt_num + (m_counter.sum() % 2), run_num, name);
+  auto uid = m_service->getUniqueID(evt_header.getEventNumber(), evt_header.getRunNumber(), name);
+  auto uid_again =
+      m_service->getUniqueID(evt_header.getEventNumber() + (m_counter.sum() % 2), evt_header.getRunNumber(), name);
   if (uid == uid_again) {
     throw std::runtime_error("Unique IDs are the same");
   }

--- a/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
+++ b/test/k4FWCoreTest/src/components/TestUniqueIDGenSvc.cpp
@@ -45,7 +45,7 @@ StatusCode TestUniqueIDGenSvc::execute(const EventContext&) const {
   evt_header.setRunNumber(3 + m_counter.sum());
   std::string name = "Some algorithm name";
 
-  auto uid = m_service->getUniqueID(evt_header.getEventNumber(), evt_header.getRunNumber(), name);
+  auto uid = m_service->getUniqueID(evt_header, name);
   auto uid_again =
       m_service->getUniqueID(evt_header.getEventNumber() + (m_counter.sum() % 2), evt_header.getRunNumber(), name);
   if (uid == uid_again) {


### PR DESCRIPTION
BEGINRELEASENOTES
- Use the same event and run type in `UniqueIDGenSvc` as in `edm4hep::EventHeader`. Add generating id directly from `edm4hep::EventHeader`. **This changes the ID values !**

ENDRELEASENOTES

Calling `getUniqueID` with arguments taken from `edm4hep::EventHeader` is the most common usage of that function. Until https://github.com/key4hep/EDM4hep/pull/398 the function arguments and `EventHeader` had different signedness.
After that PR they have the same signedness but different widths, with the function arguments being shorter - which means there is a huge range of valid `EventHeaders` that will get the same ID due to an implicit cast

I propose to deduct the correct types from `EventHeader` as in #278 and #279. I also propose to add an overload taking `EventHeader` directly since this is the most common usage and avoids a possible issue with manually assigning wrong type.

**This changes the ID values !**
