### PR TITLE
update UniqueIDGenSvc docs and add example usage in functional algorithm

### DIFF
--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -68,6 +68,9 @@ Then, use the service during execution (`execute` member function for the algori
 
 ```cpp
 StatusCode ExampleAlgorithm::execute(const EventContext&) const {
+  // Instead of passing event number and run number separately,
+  // an overload accepting EventHeader or EventHeaderCollection can be also used.
+  StatusCode sc = m_service->getUniqueID(1, 2, name());
   m_service->getUniqueID(1, 2, name());
 }
 ```
@@ -112,10 +115,10 @@ During algorithm execution the `EventHeaderCollection` can be used to obtain a u
 ```cpp
 public:
   podio::UserDataCollection<double> operator()(const edm4hep::EventHeaderCollection& evtHeader) const final {
-    const auto evt = evtHeader[0];
-
-    // obtain unique value
-    auto uid = m_uniqueIDSvc->getUniqueID(evt.getEventNumber(), evt.getRunNumber(), name());
+    // obtain unique value from the first header in a collection
+    auto uid = m_uniqueIDSvc->getUniqueID(evtHeader, name());
+    // or from a given EventHeader object
+    // auto uid = m_uniqueIDSvc->getUniqueID(evtHeader[0], name());
 
     // seed TRandom3 or some other PRNG of your choice
     auto prng = TRandom3(uid);

--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -64,7 +64,7 @@ StatusCode ExampleAlgorithm::initialize() {
   m_service = service("UniqueIDGenSvc");
 ```
 
-Then, use the service during execution:
+Then, use the service during execution (`execute` member function for the algorithms derived from `Gaudi::Algorithm` or `operator()` for functional algorithms):
 
 ```cpp
 StatusCode ExampleAlgorithm::execute(const EventContext&) const {
@@ -114,14 +114,14 @@ public:
   podio::UserDataCollection<double> operator()(const edm4hep::EventHeaderCollection& evtHeader) const final {
     const auto evt = evtHeader[0];
 
-    // obtain  unique value
+    // obtain unique value
     auto uid = m_uniqueIDSvc->getUniqueID(evt.getEventNumber(), evt.getRunNumber(), name());
 
     // seed TRandom3 or some other PRNG of your choice
     auto prng = TRandom3(uid);
 
     auto coll = podio::UserDataCollection<double>();
-    coll.push_back(a);
+    coll.push_back(prng.Rndm());
     return coll;
   }
 ```

--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -60,14 +60,14 @@ SmartIF<IUniqueIDGenSvc> m_service;
 Then, initialize the service in:
 
 ```cpp
-StatusCode SomeGaudiAlgorithm::initialize() {
+StatusCode ExampleAlgorithm::initialize() {
   m_service = service("UniqueIDGenSvc");
 ```
 
 Then, use the service during execution:
 
 ```cpp
-StatusCode MarlinProcessorWrapper::execute(const EventContext&) const {
+StatusCode ExampleAlgorithm::execute(const EventContext&) const {
   m_service->getUniqueID(1, 2, name());
 }
 ```

--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -23,7 +23,7 @@ Correctly seeding pseudo-random number generators (PRNG) is important to ensurin
 
 ## UniqueIDGenSvc service
 
-The `UniqueIDGenSvc` Gaudi service can generate unique `size_t` values that can be used as PRNG seeds, based on an event number, run number, and algorithm.
+The `UniqueIDGenSvc` Gaudi service can generate unique `size_t` values that can be used as PRNG seeds, based on an event number, run number, and algorithm name.
 
 The service can be included in a steering file by:
 

--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -52,7 +52,7 @@ k4run <steering-file> --UniqueIDGenSvc.Seed 987654321
 To use the `UniqueIDGenSvc` in a Gaudi algorithm first include the header file and declare a member variable:
 
 ```cpp
-#include <k4FWCore/IUniqueIDGenSvc.h>
+#include <k4Interface/IUniqueIDGenSvc.h>
 
 SmartIF<IUniqueIDGenSvc> m_service;
 ```

--- a/doc/uniqueIDGen.md
+++ b/doc/uniqueIDGen.md
@@ -110,7 +110,7 @@ public:
   }
 ```
 
-During algorithm execution the `EventHeaderCollection` can be used to obtain a unique value from the `UniqueIDSvc`, then the value can be used as a seed for PRNG. In this example the PRNG is then used to generate a random value and push it to an output collection.
+During algorithm execution the `EventHeaderCollection` can be used to obtain a unique value from the `m_uniqueIDSvc`, then the value can be used as a seed for PRNG. In this example the PRNG is then used to generate a random value and push it to an output collection.
 
 ```cpp
 public:

--- a/test/k4FWCoreTest/options/createEventHeader.py
+++ b/test/k4FWCoreTest/options/createEventHeader.py
@@ -21,12 +21,15 @@ from Gaudi.Configuration import *
 from Configurables import EventHeaderCreator
 from Configurables import k4DataSvc
 from Configurables import PodioOutput
+from Configurables import ExampleRNGSeedingAlg
 from k4FWCore import ApplicationMgr
 
 eventHeaderCreator = EventHeaderCreator(
     "eventHeaderCreator", runNumber=42, eventNumberOffset=42, OutputLevel=DEBUG
 )
 
+# algorithm using the header to seed a prng
+rngAlg = ExampleRNGSeedingAlg("ExampleRNGSeedingAlg")
 
 podioevent = k4DataSvc("EventDataSvc")
 
@@ -38,6 +41,7 @@ out.filename = "eventHeader.root"
 ApplicationMgr(
     TopAlg=[
         eventHeaderCreator,
+        rngAlg,
         out,
     ],
     EvtSel="NONE",

--- a/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
@@ -51,10 +51,10 @@ public:
   }
 
   podio::UserDataCollection<double> operator()(const edm4hep::EventHeaderCollection& evtHeader) const final {
-    const auto evt = evtHeader[0];
-
-    // obtain unique value
-    auto uid = m_uniqueIDSvc->getUniqueID(evt.getEventNumber(), evt.getRunNumber(), name());
+    // obtain unique value from the first header in a collection
+    auto uid = m_uniqueIDSvc->getUniqueID(evtHeader, name());
+    // or from a given EventHeader object
+    // auto uid = m_uniqueIDSvc->getUniqueID(evtHeader[0], name());
 
     // seed TRandom3 or some other PRNG of your choice
     auto prng = TRandom3(uid);

--- a/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "TRandom3.h"
+#include "edm4hep/EventHeaderCollection.h"
+#include "k4FWCore/Transformer.h"
+#include "k4Interface/IUniqueIDGenSvc.h"
+#include "podio/UserDataCollection.h"
+
+// Example functional algorithms using getUniqueID to seed a PRNG
+// Selected parts of the algorithm are shown as an example in the docs
+// doc/uniqueIDGen.md
+
+class ExampleRNGSeedingAlg final
+    : public k4FWCore::Transformer<podio::UserDataCollection<double>(const edm4hep::EventHeaderCollection&)> {
+public:
+  ExampleRNGSeedingAlg(const std::string& name, ISvcLocator* svcLoc)
+      : Transformer(name, svcLoc, {KeyValues("EventHeaderCollection", {"EventHeader"})},
+                    {KeyValues("OutputCollection", {"RandomNumbers"})}) {}
+
+  // locate the  UniqueIDGenSvc service during initialization
+  StatusCode initialize() final {
+    StatusCode sc = Transformer::initialize();
+    if (sc.isFailure()) {
+      error() << "Unable to initialize base class Service." << endmsg;
+      return sc;
+    }
+
+    m_uniqueIDSvc = service("UniqueIDGenSvc");
+    if (!m_uniqueIDSvc) {
+      error() << "Unable to locate the UniqueIDGenSvc" << endmsg;
+      return StatusCode::FAILURE;
+    }
+
+    return StatusCode::SUCCESS;
+  }
+
+  podio::UserDataCollection<double> operator()(const edm4hep::EventHeaderCollection& evtHeader) const final {
+    const auto evt = evtHeader[0];
+
+    // obtain  unique value
+    auto uid = m_uniqueIDSvc->getUniqueID(evt.getEventNumber(), evt.getRunNumber(), name());
+
+    // seed TRandom3 or some other PRNG of your choice
+    auto prng = TRandom3(uid);
+    auto coll = podio::UserDataCollection<double>();
+    coll.push_back(prng.Rndm());
+    return coll;
+  }
+
+private:
+  SmartIF<IUniqueIDGenSvc> m_uniqueIDSvc{nullptr};
+};
+
+DECLARE_COMPONENT(ExampleRNGSeedingAlg);

--- a/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleRNGSeedingAlg.cpp
@@ -53,11 +53,12 @@ public:
   podio::UserDataCollection<double> operator()(const edm4hep::EventHeaderCollection& evtHeader) const final {
     const auto evt = evtHeader[0];
 
-    // obtain  unique value
+    // obtain unique value
     auto uid = m_uniqueIDSvc->getUniqueID(evt.getEventNumber(), evt.getRunNumber(), name());
 
     // seed TRandom3 or some other PRNG of your choice
     auto prng = TRandom3(uid);
+
     auto coll = podio::UserDataCollection<double>();
     coll.push_back(prng.Rndm());
     return coll;


### PR DESCRIPTION
BEGINRELEASENOTES
- Update`UniqueIDGenSvc`documentation and add example usage with a functional algorithm

ENDRELEASENOTES

Adding a test with example functional algorithm using `UniqueIDSvc`. Selected parts of the algorithm are then copied to the documentation.

After key4hep/key4hep-doc#91 the page will be also included in the main documentation

Closes #285