### PR TITLE
Bump cvmfs-contrib action to latest version

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
     - uses: aidasoft/run-lcg-view@v4
       with:
         container: el9


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the `cvmfs-contrib` github action to lastet version `v5` to fix caching issues.

ENDRELEASENOTES
