### PR TITLE
fix typo in docs about migrating from k4DataSvc

### DIFF
--- a/doc/PodioInputOutput.md
+++ b/doc/PodioInputOutput.md
@@ -216,7 +216,7 @@ alg = SelectorAlg(
 -oup.filename = "example_output.root"
 -oup.outputCommands = ["drop MCParticles"]
 +io_svc.Output = "example_output.root"
-+oup.outputCommands = ["drop MCParticles"]
++io_svc.outputCommands = ["drop MCParticles"]
 
 
 ApplicationMgr(


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix typo in docs about migrating from `k4DataSvc`

ENDRELEASENOTES
