### PR TITLE
Remove the deprecated input and output properties in favor of Input and Output

### DIFF
--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -49,10 +49,6 @@ StatusCode IOSvc::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (!m_readingFileNamesDeprecated.empty()) {
-    warning() << ".input is deprecated, use .Input instead in the steering file" << endmsg;
-    m_readingFileNames = m_readingFileNamesDeprecated;
-  }
   if (!m_readingFileNames.empty()) {
     try {
       m_reader = podio::makeReader(m_readingFileNames.value());
@@ -68,10 +64,6 @@ StatusCode IOSvc::initialize() {
     return StatusCode::FAILURE;
   }
 
-  if (!m_writingFileNameDeprecated.empty()) {
-    warning() << ".output is deprecated, use .Output instead in the steering file" << endmsg;
-    m_writingFileName = m_writingFileNameDeprecated;
-  }
   m_nextEntry = m_firstEventEntry;
 
   m_switch = KeepDropSwitch(m_outputCommands);

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -52,9 +52,7 @@ public:
 protected:
   Gaudi::Property<std::vector<std::string>> m_collectionNames{
       this, "CollectionNames", {}, "List of collections to read"};
-  Gaudi::Property<std::vector<std::string>> m_readingFileNamesDeprecated{this, "input", {}, "List of files to read"};
   Gaudi::Property<std::vector<std::string>> m_readingFileNames{this, "Input", {}, "List of files to read"};
-  Gaudi::Property<std::string> m_writingFileNameDeprecated{this, "output", {}, "List of files to write output to"};
   Gaudi::Property<std::string> m_writingFileName{this, "Output", {}, "List of files to write output to"};
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -53,7 +53,7 @@ protected:
   Gaudi::Property<std::vector<std::string>> m_collectionNames{
       this, "CollectionNames", {}, "List of collections to read"};
   Gaudi::Property<std::vector<std::string>> m_readingFileNames{this, "Input", {}, "List of files to read"};
-  Gaudi::Property<std::string> m_writingFileName{this, "Output", {}, "List of files to write output to"};
+  Gaudi::Property<std::string>              m_writingFileName{this, "Output", {}, "List of files to write output to"};
   Gaudi::Property<std::vector<std::string>> m_outputCommands{
       this, "outputCommands", {"keep *"}, "A set of commands to declare which collections to keep or drop."};
   Gaudi::Property<std::string> m_outputType{this, "OutputType", "default",

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -62,9 +62,7 @@ class ApplicationMgr:
         """
         # First we determine whether we need to peek at all
         inp = None
-        if iosvc_props["input"][0]:
-            inp = "input"
-        elif iosvc_props["Input"][0]:
+        if iosvc_props["Input"][0]:
             inp = "Input"
 
         if not inp:
@@ -127,7 +125,7 @@ class ApplicationMgr:
             elif isinstance(alg, Writer):
                 writer = alg
         # Remove "input" when the corresponding property is removed from IOSvc
-        if reader is None and (props["input"][0] or props["Input"][0]):
+        if reader is None and props["Input"][0]:
             reader = Reader("k4FWCore__Reader")
             add_reader = True
         # It seems for a single string the default without a value is '<no value>'
@@ -135,8 +133,7 @@ class ApplicationMgr:
         # Remove "output" when the corresponding property is removed from IOSvc
         if (
             writer is None
-            and (props["output"][0] and props["output"][0] != "<no value>")
-            or (props["Output"][0] and props["Output"][0] != "<no value>")
+            and (props["Output"][0] and props["Output"][0] != "<no value>")
         ):
             writer = Writer("k4FWCore__Writer")
 

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -124,13 +124,11 @@ class ApplicationMgr:
                 reader = alg
             elif isinstance(alg, Writer):
                 writer = alg
-        # Remove "input" when the corresponding property is removed from IOSvc
         if reader is None and props["Input"][0]:
             reader = Reader("k4FWCore__Reader")
             add_reader = True
         # It seems for a single string the default without a value is '<no value>'
         # while for a list it's an empty list
-        # Remove "output" when the corresponding property is removed from IOSvc
         if writer is None and props["Output"][0] and props["Output"][0] != "<no value>":
             writer = Writer("k4FWCore__Writer")
 

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -131,10 +131,7 @@ class ApplicationMgr:
         # It seems for a single string the default without a value is '<no value>'
         # while for a list it's an empty list
         # Remove "output" when the corresponding property is removed from IOSvc
-        if (
-            writer is None
-            and (props["Output"][0] and props["Output"][0] != "<no value>")
-        ):
+        if writer is None and (props["Output"][0] and props["Output"][0] != "<no value>"):
             writer = Writer("k4FWCore__Writer")
 
         # Let's tell the Reader one of the input files so it can

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -131,7 +131,7 @@ class ApplicationMgr:
         # It seems for a single string the default without a value is '<no value>'
         # while for a list it's an empty list
         # Remove "output" when the corresponding property is removed from IOSvc
-        if writer is None and (props["Output"][0] and props["Output"][0] != "<no value>"):
+        if writer is None and props["Output"][0] and props["Output"][0] != "<no value>":
             writer = Writer("k4FWCore__Writer")
 
         # Let's tell the Reader one of the input files so it can

--- a/python/k4FWCore/IOSvc.py
+++ b/python/k4FWCore/IOSvc.py
@@ -34,10 +34,10 @@ class IOSvc:
             return
 
         # Allow to specify a single string for input when what we want is a list
-        if attr == "input" or attr == "Input":
+        if attr == "Input":
             if isinstance(value, str):
                 value = [value]
-        elif attr == "output" or attr == "Output":
+        elif attr == "Output":
             if os.path.dirname(value) and not os.path.exists(os.path.dirname(value)):
                 os.makedirs(os.path.dirname(value))
         setattr(self._svc, attr, value)

--- a/test/k4FWCoreTest/options/createEventHeaderConcurrent.py
+++ b/test/k4FWCoreTest/options/createEventHeaderConcurrent.py
@@ -46,7 +46,7 @@ eventHeaderCreator = EventHeaderCreator(
 )
 
 svc = IOSvc("IOSvc")
-svc.output = "eventHeaderConcurrent.root"
+svc.Output = "eventHeaderConcurrent.root"
 
 ApplicationMgr(
     TopAlg=[eventHeaderCreator],


### PR DESCRIPTION
Now substituted by their upper-cased variant `Input` and `Output`.

BEGINRELEASENOTES
- Remove the deprecated `input` and `output` properties for IOSvc

ENDRELEASENOTES

This will remove the warning that was reported in https://github.com/key4hep/k4FWCore/issues/240.