### PR TITLE
Remove the hardcoded collections in the CollectionMerger and fix merging link collections

### DIFF
--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -101,13 +101,9 @@ private:
     const auto ptr = static_cast<T*>(ret);
     const auto sourceColl = static_cast<const T*>(source);
     if (m_copy) {
-      for (const auto& elem : *sourceColl) {
-        ptr->push_back(elem.clone());
-      }
+      std::ranges::transform(*sourceColl, std::back_inserter(*ptr), [](const auto& elem) { return elem.clone(); });
     } else {
-      for (const auto& elem : *sourceColl) {
-        ptr->push_back(elem);
-      }
+      std::ranges::copy(*sourceColl, std::back_inserter(*ptr));
     }
   }
 };

--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -33,6 +33,8 @@
  *  The output collection is specified in the OutputCollection property.
  */
 
+#include <podio/utilities/TypeHelpers.h>
+
 #include "edm4hep/edm4hep.h"
 
 #include "k4FWCore/Transformer.h"
@@ -40,6 +42,7 @@
 #include <map>
 #include <string>
 #include <string_view>
+#include <vector>
 
 struct CollectionMerger final
     : k4FWCore::Transformer<podio::CollectionBase*(const std::vector<const podio::CollectionBase*>&)> {

--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -54,6 +54,7 @@ struct CollectionMerger final
     }
 
     addToMapAll(edm4hep::edm4hepDataTypes{});
+    addToMapAll(edm4hep::edm4hepLinkTypes{});
   }
 
   podio::CollectionBase* operator()(const std::vector<const podio::CollectionBase*>& input) const override {

--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -49,45 +49,8 @@ struct CollectionMerger final
     if (System::cmdLineArgs()[0].find("genconf") != std::string::npos) {
       return;
     }
-    m_map["edm4hep::MCParticleCollection"] = &CollectionMerger::mergeCollections<edm4hep::MCParticleCollection>;
-    m_map["edm4hep::SimTrackerHitCollection"] = &CollectionMerger::mergeCollections<edm4hep::SimTrackerHitCollection>;
-    m_map["edm4hep::CaloHitContributionCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::CaloHitContributionCollection>;
-    m_map["edm4hep::SimCalorimeterHitCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::SimCalorimeterHitCollection>;
-    m_map["edm4hep::RawCalorimeterHitCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::RawCalorimeterHitCollection>;
-    m_map["edm4hep::CalorimeterHitCollection"] = &CollectionMerger::mergeCollections<edm4hep::CalorimeterHitCollection>;
-    m_map["edm4hep::ParticleIDCollection"] = &CollectionMerger::mergeCollections<edm4hep::ParticleIDCollection>;
-    m_map["edm4hep::ClusterCollection"] = &CollectionMerger::mergeCollections<edm4hep::ClusterCollection>;
-    m_map["edm4hep::TrackerHit3DCollection"] = &CollectionMerger::mergeCollections<edm4hep::TrackerHit3DCollection>;
-    m_map["edm4hep::TrackerHitPlaneCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::TrackerHitPlaneCollection>;
-    m_map["edm4hep::RawTimeSeriesCollection"] = &CollectionMerger::mergeCollections<edm4hep::RawTimeSeriesCollection>;
-    m_map["edm4hep::TrackCollection"] = &CollectionMerger::mergeCollections<edm4hep::TrackCollection>;
-    m_map["edm4hep::VertexCollection"] = &CollectionMerger::mergeCollections<edm4hep::VertexCollection>;
-    m_map["edm4hep::ReconstructedParticleCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::ReconstructedParticleCollection>;
-    m_map["edm4hep::RecoMCParticleLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::RecoMCParticleLinkCollection>;
-    m_map["edm4hep::CaloHitSimCaloHitLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::CaloHitSimCaloHitLinkCollection>;
-    m_map["edm4hep::TrackerHitSimTrackerHitLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::TrackerHitSimTrackerHitLinkCollection>;
-    m_map["edm4hep::CaloHitMCParticleLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::CaloHitMCParticleLinkCollection>;
-    m_map["edm4hep::ClusterMCParticleLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::ClusterMCParticleLinkCollection>;
-    m_map["edm4hep::TrackMCParticleLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::TrackMCParticleLinkCollection>;
-    m_map["edm4hep::VertexRecoParticleLinkCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::VertexRecoParticleLinkCollection>;
-    m_map["edm4hep::TimeSeriesCollection"] = &CollectionMerger::mergeCollections<edm4hep::TimeSeriesCollection>;
-    m_map["edm4hep::RecDqdxCollection"] = &CollectionMerger::mergeCollections<edm4hep::RecDqdxCollection>;
-    m_map["edm4hep::GeneratorEventParametersCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::GeneratorEventParametersCollection>;
-    m_map["edm4hep::GeneratorPdfInfoCollection"] =
-        &CollectionMerger::mergeCollections<edm4hep::GeneratorPdfInfoCollection>;
+
+    addToMapAll(edm4hep::edm4hepDataTypes{});
   }
 
   podio::CollectionBase* operator()(const std::vector<const podio::CollectionBase*>& input) const override {
@@ -112,6 +75,16 @@ private:
   std::map<std::string_view, MergeType> m_map;
   Gaudi::Property<bool> m_copy{this, "Copy", false,
                                "Copy the elements of the collections instead of creating a subset collection"};
+
+  template <typename T>
+  void addToMap() {
+    m_map[T::collection_type::typeName] = &CollectionMerger::mergeCollections<typename T::collection_type>;
+  }
+
+  template <typename... T>
+  void addToMapAll(podio::utils::TypeList<T...>&&) {
+    (addToMap<T>(), ...);
+  }
 
   template <typename T>
   void mergeCollections(const podio::CollectionBase* source, podio::CollectionBase*& ret) const {

--- a/test/k4FWCoreTest/options/ExampleFunctionalCollectionMerger.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalCollectionMerger.py
@@ -37,6 +37,8 @@ svc.outputCommands = [
     "keep MCParticles3",
     "keep NewMCParticles",
     "keep SimTrackerHits",
+    "keep Links",
+    "keep NewLinks",
 ]
 
 
@@ -54,11 +56,19 @@ merger = CollectionMerger(
     OutputLevel=DEBUG,
 )
 
+link_merger = CollectionMerger(
+    "LinkCollectionMerger",
+    # List of collections to concatenate
+    InputCollections=["Links", "Links"],
+    # Name of the single output collection
+    OutputCollection=["NewLinks"],
+)
+
 # If we want to copy instead of creating a subset collection
 # merger.Copy = True
 
 mgr = ApplicationMgr(
-    TopAlg=[particle_producer, merger],
+    TopAlg=[particle_producer, merger, link_merger],
     EvtSel="NONE",
     EvtMax=-1,
     ExtSvc=[EventDataSvc("EventDataSvc")],

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -184,7 +184,15 @@ for i in range(2):
 
 check_collections(
     "functional_merged_collections.root",
-    ["MCParticles1", "MCParticles2", "MCParticles3", "NewMCParticles", "SimTrackerHits"],
+    [
+        "MCParticles1",
+        "MCParticles2",
+        "MCParticles3",
+        "NewMCParticles",
+        "SimTrackerHits",
+        "Links",
+        "NewLinks",
+    ],
 )
 
 podio_reader = podio.root_io.Reader("functional_merged_collections.root")
@@ -195,11 +203,21 @@ merged_mc_colls = [ev.get(f"MCParticles{i}") for i in range(1, 4)]
 merged_mcs = [mcc[i] for mcc in merged_mc_colls for i in range(len(mcc))]
 if len(new_mcs) != len(merged_mcs):
     raise RuntimeError(f"Expected {len(merged_mcs)} NewMCParticles but got {len(new_mcs)}")
-
 for new_mc, orig_mc in zip(new_mcs, merged_mcs):
     if new_mc.id() != orig_mc.id():
         raise RuntimeError(
             f"merged mcs do not match, expected [{new_mc.id().collectionID}, {new_mc.id().index}], actual [{orig_mc.id().collectionID}, {orig_mc.id().index}]"
+        )
+links = ev.get("Links")
+merged_links = ev.get("NewLinks")
+if len(links) * 2 != len(merged_links):
+    raise RuntimeError(f"Expected {len(links)} NewLinks but got {len(merged_links)}")
+for i in range(len(merged_links)):
+    link = links[i % len(links)]
+    merged_link = merged_links[i]
+    if link.id() != merged_link.id():
+        raise RuntimeError(
+            f"merged links do not match, expected [{link.id().collectionID}, {link.id().index}], actual [{merged_link.id().collectionID}, {merged_link.id().index}]"
         )
 
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the hardcoded collections in the CollectionMerger, using https://github.com/AIDASoft/podio/pull/761. This applies to all collections that are available in EDM4hep.
- Fix link collections that are currently not working since the data type name is not `edm4hep::...LinkCollection` but `podio::LinkCollection...`
- Require a newer version of podio in the CMakeLists.txt 

ENDRELEASENOTES

There is not a tag in podio with https://github.com/AIDASoft/podio/pull/761 so this PR can't be merged yet.