### PR TITLE
Fix using k4run with pipes, like `| head`, and add a test

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -114,6 +114,7 @@ def add_arguments(parser, app_mgr):
             )
     return option_db
 
+
 def main():
     # ensure that we (and the subprocesses) use the C standard localization
     os.environ["LC_ALL"] = "C"

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -4,8 +4,12 @@ import os
 import sys
 import argparse
 import logging
+import signal
 
 from k4FWCore.utils import load_file
+
+# Terminate the process if a SIGPIPE is received
+signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
 # these default properties are filtered as otherwise they will clutter the argument list
 FILTER_GAUDI_PROPS = [
@@ -110,17 +114,6 @@ def add_arguments(parser, app_mgr):
             )
     return option_db
 
-
-class LoggingHandler(logging.StreamHandler):
-    def handleError(self, record):
-        # Re-raise SIGPIPE generated exception
-        excp = sys.exc_info()[1]  # from Python 3.11 can be replaced with sys.exception()
-        if isinstance(excp, BrokenPipeError):
-            raise excp
-
-        super().handleError(record)
-
-
 def main():
     # ensure that we (and the subprocesses) use the C standard localization
     os.environ["LC_ALL"] = "C"
@@ -128,9 +121,7 @@ def main():
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     formatter = logging.Formatter("[k4run] %(message)s")
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-    logger.handlers = [handler]
+    logger.handlers[0].setFormatter(formatter)
 
     from k4FWCore.parseArgs import parser
 
@@ -254,11 +245,4 @@ def main():
 
 
 if __name__ == "__main__":
-    try:
-        main()
-    except BrokenPipeError:
-        # Handle SIGPIPE generated exception
-        devnull = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull, sys.stdout.fileno())
-        os.dup2(devnull, sys.stderr.fileno())
-        sys.exit(1)
+    main()

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -223,9 +223,7 @@ add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py P
 add_test_with_env(ReadMarlinWrapperCollection options/readMarlinWrapperCollection.py)
 
 add_test(NAME check_broken_pipe
-         COMMAND bash -c "${K4RUN} options/ExampleFunctionalProducer.py | head -n 2 | wc -l"
+         COMMAND bash -c "[ $(${K4RUN} options/ExampleFunctionalProducer.py | head -n 2 | wc -l) = 2 ]"
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
        )
-
-set_tests_properties(check_broken_pipe PROPERTIES PASS_REGULAR_EXPRESSION "^2")
 set_test_env(check_broken_pipe)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -221,3 +221,11 @@ add_test_with_env(TypeMisMatchDemo options/TypeMisMatchDemo.py PROPERTIES PASS_R
 
 add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py PROPERTIES PASS_REGULAR_EXPRESSION "Failed to cast collection MCParticles1 to the required type")
 add_test_with_env(ReadMarlinWrapperCollection options/readMarlinWrapperCollection.py)
+
+add_test(NAME check_broken_pipe
+         COMMAND bash -c "k4run options/ExampleFunctionalProducer.py | head -n 2 | wc -l"
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+       )
+
+set_tests_properties(check_broken_pipe PROPERTIES PASS_REGULAR_EXPRESSION "^2")
+set_test_env(check_ParticleIDOutputs)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -223,7 +223,7 @@ add_test_with_env(TypeMisMatchDemoMultiple options/TypeMisMatchDemoMultiple.py P
 add_test_with_env(ReadMarlinWrapperCollection options/readMarlinWrapperCollection.py)
 
 add_test(NAME check_broken_pipe
-         COMMAND bash -c "k4run options/ExampleFunctionalProducer.py | head -n 2 | wc -l"
+         COMMAND bash -c "${K4RUN} options/ExampleFunctionalProducer.py | head -n 2 | wc -l"
          WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
        )
 

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -228,4 +228,4 @@ add_test(NAME check_broken_pipe
        )
 
 set_tests_properties(check_broken_pipe PROPERTIES PASS_REGULAR_EXPRESSION "^2")
-set_test_env(check_ParticleIDOutputs)
+set_test_env(check_broken_pipe)


### PR DESCRIPTION
BEGINRELEASENOTES
- Use signal to stop immediately after receiving a SIGPIPE. Before, the output from k4run itself would always print and the pipe command (for example `| head`) would only be applied to the output from Gaudi.
- Add a test that uses pipes

ENDRELEASENOTES

Found in https://github.com/key4hep/k4FWCore/pull/306#discussion_r2066168920. See also https://github.com/key4hep/k4FWCore/pull/186, when handling of SIGPIPE was initially introduced.