### PR TITLE
Unset DISPLAY to avoid importing ROOT when not showing plots

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -262,7 +262,7 @@ def main():
     gaudi = gaudimain()
     if not opts.dry_run:
         if not opts.interactive_root:
-            os.environ.pop("DISPLAY")
+            os.environ.pop("DISPLAY", None)
 
         # Do the real processing
         retcode = gaudi.run(opts.gdb)

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -262,7 +262,7 @@ def main():
     gaudi = gaudimain()
     if not opts.dry_run:
         if not opts.interactive_root:
-            os.environ.pop('DISPLAY')
+            os.environ.pop("DISPLAY")
 
         # Do the real processing
         retcode = gaudi.run(opts.gdb)

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -262,9 +262,7 @@ def main():
     gaudi = gaudimain()
     if not opts.dry_run:
         if not opts.interactive_root:
-            from ROOT import gROOT
-
-            gROOT.SetBatch(True)
+            os.environ.pop('DISPLAY')
 
         # Do the real processing
         retcode = gaudi.run(opts.gdb)


### PR DESCRIPTION
BEGINRELEASENOTES
- Unset DISPLAY to avoid importing ROOT when not showing plots

ENDRELEASENOTES

In my testing unsetting the environment variable `DISPLAY` seems to be enough to disable showing plots. The reason to do this is that importing ROOT is slow (on my desktop it is ~0.5 seconds) so it's better if we can avoid it. 

If DISPLAY is set, then batch mode is guaranteed not to be set: https://github.com/root-project/root/blob/ee9e36b3c7b9209a5ae1f1f4f7a8e4afba104c25/core/base/src/TROOT.cxx#L875

Can you please test it @Zehvogel (since you found this originally in https://github.com/key4hep/k4FWCore/pull/207)? You can copy and paste the k4run script in this PR without building anything.

I also thought about changing the option from `--interactive-root` to `--interactive-graphics` since all graphics will be disabled (I think), but it's true that most likely it's ROOT graphics what someone wants to see.