### PR TITLE
Bump the required version of podio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_
 
 find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
-find_package(podio 1.2.99 REQUIRED)
+find_package(podio 1.3 REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
 find_package(fmt REQUIRED)
 


### PR DESCRIPTION
k4FWCore needs 1.3 since https://github.com/key4hep/k4FWCore/pull/305


BEGINRELEASENOTES
- Bump the required version of podio. 1.3 is needed since https://github.com/key4hep/k4FWCore/pull/305 because of `edm4hep::DataTypes` and `edm4hep::LinkTypes`

ENDRELEASENOTES