### PR TITLE
Use the Warnings property only if it exists for EventLoopMgr

### DIFF
--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -114,12 +114,10 @@ class ApplicationMgr:
         if not hasattr(self._mgr, "EventLoop"):
             self._mgr.EventLoop = EventLoopMgr()
             try:
-                # Only available in Gaudi >= 40.0.0, when the Warnings attribute is removed
-                from Gaudi import __version__  # noqa: F401
-
-                self._mgr.EventLoop.OutputLevel = WARNING
-            except ImportError:
                 self._mgr.EventLoop.Warnings = False
+            # Warnings doesn't exist after v40
+            except AttributeError:
+                self._mgr.EventLoop.OutputLevel = WARNING
 
         if "MetadataSvc" in self._mgr.allConfigurables:
             self._mgr.ExtSvc.append(self._mgr.allConfigurables["MetadataSvc"])

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -105,10 +105,12 @@ class ApplicationMgr:
         # This will suppress two warnings about not using external input
         if not hasattr(self._mgr, "EventLoop"):
             self._mgr.EventLoop = EventLoopMgr()
-            if hasattr(self._mgr.EventLoop, "Warnings"):
-                self._mgr.EventLoop.Warnings = False
-            else:
+            try:
+                # Only available in Gaudi >= 40.0.0, when the Warnings attribute is removed
+                from Gaudi import __version__  # noqa: F401
                 self._mgr.EventLoop.OutputLevel = WARNING
+            except ImportError:
+                self._mgr.EventLoop.Warnings = False
 
         if "MetadataSvc" in self._mgr.allConfigurables:
             self._mgr.ExtSvc.append(self._mgr.allConfigurables["MetadataSvc"])

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -108,6 +108,7 @@ class ApplicationMgr:
             try:
                 # Only available in Gaudi >= 40.0.0, when the Warnings attribute is removed
                 from Gaudi import __version__  # noqa: F401
+
                 self._mgr.EventLoop.OutputLevel = WARNING
             except ImportError:
                 self._mgr.EventLoop.Warnings = False

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -18,11 +18,13 @@
 #
 import logging
 
+from Gaudi import Configuration
 from Configurables import ApplicationMgr as AppMgr
 from Configurables import Reader, Writer, IOSvc, Gaudi__Sequencer, EventLoopMgr
 from Gaudi.Configuration import WARNING
+from k4FWCore.utils import get_logger
 
-logger = logging.getLogger()
+logger = get_logger()
 
 
 class ApplicationMgr:

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -42,6 +42,12 @@ class ApplicationMgr:
 
     def __init__(self, **kwargs):
         self._mgr = AppMgr(**kwargs)
+        try:
+            self._mgr.OutputLevel = getattr(Configuration, logging.getLevelName(logger.level))
+        except AttributeError:
+            logger.warning(
+                f"{logging.getLevelName(logger.level)} (from log level {logger.level}) is not a valid OutputLevel for Gaudi"
+            )
 
     def _setup_reader(self, reader, iosvc_props):
         """Setup the reader consistently such that it has sane defaults

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -115,7 +115,7 @@ class ApplicationMgr:
             self._mgr.EventLoop = EventLoopMgr()
             try:
                 self._mgr.EventLoop.Warnings = False
-            # Warnings doesn't exist after v40
+            # Warnings doesn't exist after Gaudi v40
             except AttributeError:
                 self._mgr.EventLoop.OutputLevel = WARNING
 

--- a/test/k4FWCoreTest/options/ExampleFunctionalMTFile.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMTFile.py
@@ -37,7 +37,6 @@ whiteboard = HiveWhiteBoard(
 slimeventloopmgr = HiveSlimEventLoopMgr(
     "HiveSlimEventLoopMgr",
     SchedulerName="AvalancheSchedulerSvc",
-    Warnings=False,
     OutputLevel=WARNING,
 )
 

--- a/test/k4FWCoreTest/options/ExampleFunctionalMTMemory.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMTMemory.py
@@ -39,7 +39,7 @@ whiteboard = HiveWhiteBoard(
 )
 
 slimeventloopmgr = HiveSlimEventLoopMgr(
-    SchedulerName="AvalancheSchedulerSvc", Warnings=False, OutputLevel=WARNING
+    SchedulerName="AvalancheSchedulerSvc", OutputLevel=WARNING
 )
 
 scheduler = AvalancheSchedulerSvc(ThreadPoolSize=threads, OutputLevel=WARNING)

--- a/test/k4FWCoreTest/options/ExampleFunctionalMTMemory.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMTMemory.py
@@ -38,9 +38,7 @@ whiteboard = HiveWhiteBoard(
     ForceLeaves=True,
 )
 
-slimeventloopmgr = HiveSlimEventLoopMgr(
-    SchedulerName="AvalancheSchedulerSvc", OutputLevel=WARNING
-)
+slimeventloopmgr = HiveSlimEventLoopMgr(SchedulerName="AvalancheSchedulerSvc", OutputLevel=WARNING)
 
 scheduler = AvalancheSchedulerSvc(ThreadPoolSize=threads, OutputLevel=WARNING)
 scheduler.ShowDataDependencies = True

--- a/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalTransformerHist.py
@@ -19,7 +19,7 @@
 
 # This is an example using two producers that create histograms and persist them to a ROOT file
 
-from Gaudi.Configuration import INFO
+from Gaudi.Configuration import INFO, WARNING
 from Configurables import ExampleFunctionalProducer, ExampleFunctionalTransformerHist
 from k4FWCore import ApplicationMgr
 from Configurables import RootHistSvc
@@ -39,8 +39,7 @@ if multithreaded:
     slimeventloopmgr = HiveSlimEventLoopMgr(
         "HiveSlimEventLoopMgr",
         SchedulerName="AvalancheSchedulerSvc",
-        Warnings=False,
-        OutputLevel=INFO,
+        OutputLevel=WARNING,
     )
 
     scheduler = AvalancheSchedulerSvc(ThreadPoolSize=threads, OutputLevel=INFO)

--- a/test/k4FWCoreTest/options/TestEventCounter.py
+++ b/test/k4FWCoreTest/options/TestEventCounter.py
@@ -38,7 +38,6 @@ whiteboard = HiveWhiteBoard(
 slimeventloopmgr = HiveSlimEventLoopMgr(
     "HiveSlimEventLoopMgr",
     SchedulerName="AvalancheSchedulerSvc",
-    Warnings=False,
     OutputLevel=WARNING,
 )
 


### PR DESCRIPTION
It has been removed in Gaudi in https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/993, which will appear first in 40.0. This is currently silencing these two warnings:

```
  EventLoopMgr      WARNING Unable to locate service "EventSelector"
  EventLoopMgr      WARNING No events will be processed from external input.
```

that would always appear otherwise since we don't use the EventSelector. These changes change the output level of the default EventLoopMgr to WARNING but since these two warnings have been demoted to INFO, they will still be silenced.

BEGINRELEASENOTES
- Use the Warnings property only if it exists for EventLoopMgr
- Do not use the Warnings property in the tests since it is going to be removed (warnings will not be silenced in these tests before v40r0)

ENDRELEASENOTES
https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1740 has been merged and it will appear in v40, giving us a way of knowing if we are on 40.0.