### PR TITLE
Move the DataHandle into the k4FWCore namespace

### DIFF
--- a/k4FWCore/components/EventHeaderCreator.h
+++ b/k4FWCore/components/EventHeaderCreator.h
@@ -49,8 +49,8 @@ private:
       "Event number offset, eventNumber will be filled with 'event_index + eventNumberOffset'"};
 
   // datahandle for the EventHeader
-  mutable DataHandle<edm4hep::EventHeaderCollection> m_headerCol{edm4hep::labels::EventHeader,
-                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::EventHeaderCollection> m_headerCol{edm4hep::labels::EventHeader,
+                                                                           Gaudi::DataHandle::Writer, this};
 };
 
 #endif

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -28,6 +28,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+namespace k4FWCore {
 /**
  * Specialisation of the Gaudi DataHandle
  * for use with podio collections.
@@ -165,13 +166,17 @@ T* DataHandle<T>::createAndPut() {
   this->put(objectp);
   return objectp;
 }
+} // namespace k4FWCore
+
+template <typename T>
+using DataHandle [[deprecated("Use k4FWCore::DataHandle instead")]] = k4FWCore::DataHandle<T>;
 
 // temporary to allow property declaration
 namespace Gaudi {
 template <class T>
-class Property<::DataHandle<T>&> : public ::DataHandleProperty {
+class Property<k4FWCore::DataHandle<T>&> : public ::DataHandleProperty {
 public:
-  Property(const std::string& name, ::DataHandle<T>& value) : ::DataHandleProperty(name, value) {}
+  Property(const std::string& name, k4FWCore::DataHandle<T>& value) : ::DataHandleProperty(name, value) {}
 };
 } // namespace Gaudi
 

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -25,8 +25,10 @@
 #include "podio/CollectionBase.h"
 
 // forward declaration
+namespace k4FWCore {
 template <typename T>
 class DataHandle;
+}
 
 class GAUDI_API DataWrapperBase : public DataObject {
 public:
@@ -40,7 +42,7 @@ template <class T>
 class GAUDI_API DataWrapper : public DataWrapperBase {
 public:
   template <class T2>
-  friend class DataHandle;
+  friend class k4FWCore::DataHandle;
 
 public:
   DataWrapper() : m_data(nullptr) {}

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -24,6 +24,8 @@
 #include "k4FWCore/MetadataUtils.h"
 #include "k4FWCore/PodioDataSvc.h"
 
+namespace k4FWCore {
+
 template <typename T>
 class MetaDataHandle {
 public:
@@ -164,5 +166,9 @@ void MetaDataHandle<T>::checkPodioDataSvc() {
     std::cout << "Warning: MetaDataHandles require the PodioDataSvc or for compatibility the MetadataSvc" << std::endl;
   }
 }
+} // namespace k4FWCore
+
+template <typename T>
+using MetaDataHandle [[deprecated("Use k4FWCore::MetaDataHandle instead")]] = k4FWCore::MetaDataHandle<T>;
 
 #endif

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -31,8 +31,10 @@
 #include "k4FWCore/DataWrapper.h"
 class DataWrapperBase;
 class PodioOutput;
+namespace k4FWCore {
 template <typename T>
 class MetaDataHandle;
+}
 
 /** @class PodioEvtSvc EvtDataSvc.h
  *
@@ -42,7 +44,7 @@ class MetaDataHandle;
  */
 class PodioDataSvc : public DataSvc {
   template <typename T>
-  friend class MetaDataHandle;
+  friend class k4FWCore::MetaDataHandle;
   friend class PodioOutput;
   friend class Lcio2EDM4hepTool;
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
@@ -62,13 +62,14 @@ private:
   Gaudi::Property<int> m_magicNumberOffset{this, "magicNumberOffset", 0,
                                            "Integer to add to the dummy values written to the edm"};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Writer, this};
   /// Handle for the genvertices to be written
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHit", Gaudi::DataHandle::Writer,
-                                                                             this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHit",
+                                                                                       Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer,
-                                                                           this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Writer, this};
 
   /// for testing: write a second TFile by user in an algorithm
   mutable Float_t m_value;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -47,9 +47,10 @@ private:
   Gaudi::Property<bool> m_keepEventNumberZero{this, "keepEventNumberZero", false,
                                               "Don't add the event number to the dummy values written"};
   /// Handle for the MCParticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Reader,
-                                                                           this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Reader, this};
 
   mutable int m_event{0};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -51,19 +51,21 @@ private:
   /// integer to add to the dummy values written to the edm
   Gaudi::Property<int> m_magicNumberOffset{this, "magicNumberOffset", 0,
                                            "Integer to add to the dummy values written to the edm"};
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHits",
-                                                                             Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_TrackerHitHandle{"TrackerHits", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHits",
+                                                                                       Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_TrackerHitHandle{"TrackerHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<edm4hep::TrackCollection> m_trackHandle{"Tracks", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackCollection> m_trackHandle{"Tracks", Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer,
-                                                                           this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoHandle{"RecoParticles", Gaudi::DataHandle::Writer,
-                                                                            this};
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_linkHandle{"Links", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> m_recoHandle{"RecoParticles",
+                                                                                      Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::RecoMCParticleLinkCollection> m_linkHandle{"Links", Gaudi::DataHandle::Writer,
+                                                                                   this};
 
   mutable int m_event{0};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -43,8 +43,8 @@ public:
 
 private:
   /// Handle for the SimTrackerHits to be read
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{"SimTrackerHits",
-                                                                                   Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{
+      "SimTrackerHits", Gaudi::DataHandle::Reader, this};
   mutable MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding,
                                                      Gaudi::DataHandle::Reader};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -45,7 +45,7 @@ private:
   /// Handle for the SimTrackerHits to be read
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{
       "SimTrackerHits", Gaudi::DataHandle::Reader, this};
-  mutable MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding,
-                                                     Gaudi::DataHandle::Reader};
+  mutable k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{
+      m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
 };
 #endif /* K4FWCORE_K4FWCORETEST_CELLID */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -52,8 +52,8 @@ private:
   /// Handle for the SimTrackerHits to be written
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{
       "SimTrackerHits", Gaudi::DataHandle::Writer, this};
-  MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
-                                             Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
+                                                       Gaudi::DataHandle::Writer};
 
   // Some properties for the configuration metadata
   Gaudi::Property<int> m_intProp{this, "intProp", 42, "An integer property"};

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -50,8 +50,8 @@ public:
 
 private:
   /// Handle for the SimTrackerHits to be written
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{"SimTrackerHits",
-                                                                                   Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{
+      "SimTrackerHits", Gaudi::DataHandle::Writer, this};
   MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
                                              Gaudi::DataHandle::Writer};
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Move the `DataHandle` and `MetaDataHandle` into the `k4FWCore` namespace to make origins more obvious
  - Keep deprecated `DataHandle` and `MetaDataHandle` aliases in global namespace for compatibility to allow for a smoother migration

ENDRELEASENOTES


This is a small part that fell out of work for deprecating the `PodioDataSvc` and relatives. I think most of our stuff should actually live in the `k4FWCore` namespace and not just in the global namespace to avoid confusion.