### PR TITLE
Restrict datahandle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_
 
 find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
-find_package(podio 1.2.99 REQUIRED)
+find_package(podio 1.3 REQUIRED)
 find_package(EDM4HEP 0.99 REQUIRED)
 find_package(fmt REQUIRED)
 

--- a/k4FWCore/components/EventHeaderCreator.h
+++ b/k4FWCore/components/EventHeaderCreator.h
@@ -49,8 +49,8 @@ private:
       "Event number offset, eventNumber will be filled with 'event_index + eventNumberOffset'"};
 
   // datahandle for the EventHeader
-  mutable DataHandle<edm4hep::EventHeaderCollection> m_headerCol{edm4hep::labels::EventHeader,
-                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::EventHeaderCollection> m_headerCol{edm4hep::labels::EventHeader,
+                                                                           Gaudi::DataHandle::Writer, this};
 };
 
 #endif

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -19,6 +19,8 @@
 #ifndef K4FWCORE_DATAHANDLE_H
 #define K4FWCORE_DATAHANDLE_H
 
+#include <podio/utilities/TypeHelpers.h>
+
 #include "k4FWCore/DataWrapper.h"
 #include "k4FWCore/PodioDataSvc.h"
 
@@ -33,7 +35,7 @@ namespace k4FWCore {
  * Specialisation of the Gaudi DataHandle
  * for use with podio collections.
  */
-template <typename T>
+template <podio::CollectionType T>
 class DataHandle : public DataObjectHandle<DataWrapper<T>> {
 public:
   friend class Algorithm;
@@ -71,7 +73,7 @@ private:
   T* m_dataPtr;
 };
 
-template <typename T>
+template <podio::CollectionType T>
 DataHandle<T>::~DataHandle() {
   // release memory allocated for primitive types (see comments in ctor)
   if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
@@ -80,11 +82,11 @@ DataHandle<T>::~DataHandle() {
 }
 
 //---------------------------------------------------------------------------
-template <typename T>
+template <podio::CollectionType T>
 DataHandle<T>::DataHandle(DataObjID& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)
     : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {}
 
-template <typename T>
+template <podio::CollectionType T>
 DataHandle<T>::DataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)
     : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {
   if (a == Gaudi::DataHandle::Writer) {
@@ -106,7 +108,7 @@ DataHandle<T>::DataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode
  * If this is not the first time we cast and the cast worked, just use the
  * static cast: we do not need the checks of the dynamic cast for every access!
  */
-template <typename T>
+template <podio::CollectionType T>
 const T* DataHandle<T>::get() {
   DataObject* dataObjectp;
   auto sc = m_eds->retrieveObject(DataObjectHandle<DataWrapper<T>>::fullKey().key(), dataObjectp);
@@ -133,7 +135,7 @@ const T* DataHandle<T>::get() {
 }
 
 //---------------------------------------------------------------------------
-template <typename T>
+template <podio::CollectionType T>
 void DataHandle<T>::put(T* objectp) {
   std::unique_ptr<DataWrapper<T>> dw = std::make_unique<DataWrapper<T>>();
   // in case T is of primitive type, we must not change the pointer address
@@ -148,7 +150,7 @@ void DataHandle<T>::put(T* objectp) {
 }
 
 //---------------------------------------------------------------------------
-template <typename T>
+template <podio::CollectionType T>
 T* DataHandle<T>::put(std::unique_ptr<T> objectp) {
   put(objectp.get());
   return objectp.release();
@@ -160,7 +162,7 @@ T* DataHandle<T>::put(std::unique_ptr<T> objectp) {
  * pointer to the data. Call this function if you create a collection and
  * want to save it.
  */
-template <typename T>
+template <podio::CollectionType T>
 T* DataHandle<T>::createAndPut() {
   T* objectp = new T();
   this->put(objectp);
@@ -168,7 +170,7 @@ T* DataHandle<T>::createAndPut() {
 }
 } // namespace k4FWCore
 
-template <typename T>
+template <podio::CollectionType T>
 using DataHandle [[deprecated("Use k4FWCore::DataHandle instead")]] = k4FWCore::DataHandle<T>;
 
 // temporary to allow property declaration

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -28,6 +28,7 @@
 #include <stdexcept>
 #include <type_traits>
 
+namespace k4FWCore {
 /**
  * Specialisation of the Gaudi DataHandle
  * for use with podio collections.
@@ -165,13 +166,17 @@ T* DataHandle<T>::createAndPut() {
   this->put(objectp);
   return objectp;
 }
+} // namespace k4FWCore
+
+template <typename T>
+using DataHandle [[deprecated("Use k4FWCore::DataHandle instead")]] = k4FWCore::DataHandle<T>;
 
 // temporary to allow property declaration
 namespace Gaudi {
 template <class T>
-class Property<::DataHandle<T>&> : public ::DataHandleProperty {
+class Property<k4FWCore::DataHandle<T>&> : public ::DataHandleProperty {
 public:
-  Property(const std::string& name, ::DataHandle<T>& value) : ::DataHandleProperty(name, value) {}
+  Property(const std::string& name, k4FWCore::DataHandle<T>& value) : ::DataHandleProperty(name, value) {}
 };
 } // namespace Gaudi
 

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -38,10 +38,6 @@ namespace k4FWCore {
 template <podio::CollectionType T>
 class DataHandle : public DataObjectHandle<DataWrapper<T>> {
 public:
-  friend class Algorithm;
-  friend class AlgTool;
-
-public:
   DataHandle();
   ~DataHandle() override;
 

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -25,8 +25,10 @@
 #include "podio/CollectionBase.h"
 
 // forward declaration
+namespace k4FWCore {
 template <typename T>
 class DataHandle;
+}
 
 class GAUDI_API DataWrapperBase : public DataObject {
 public:
@@ -40,7 +42,7 @@ template <class T>
 class GAUDI_API DataWrapper : public DataWrapperBase {
 public:
   template <class T2>
-  friend class DataHandle;
+  friend class k4FWCore::DataHandle;
 
 public:
   DataWrapper() : m_data(nullptr) {}

--- a/k4FWCore/include/k4FWCore/DataWrapper.h
+++ b/k4FWCore/include/k4FWCore/DataWrapper.h
@@ -22,11 +22,13 @@
 #include <type_traits>
 
 #include "GaudiKernel/DataObject.h"
+
 #include "podio/CollectionBase.h"
+#include "podio/utilities/TypeHelpers.h"
 
 // forward declaration
 namespace k4FWCore {
-template <typename T>
+template <podio::CollectionType T>
 class DataHandle;
 }
 
@@ -41,7 +43,7 @@ public:
 template <class T>
 class GAUDI_API DataWrapper : public DataWrapperBase {
 public:
-  template <class T2>
+  template <podio::CollectionType T2>
   friend class k4FWCore::DataHandle;
 
 public:

--- a/k4FWCore/include/k4FWCore/MetaDataHandle.h
+++ b/k4FWCore/include/k4FWCore/MetaDataHandle.h
@@ -24,6 +24,8 @@
 #include "k4FWCore/MetadataUtils.h"
 #include "k4FWCore/PodioDataSvc.h"
 
+namespace k4FWCore {
+
 template <typename T>
 class MetaDataHandle {
 public:
@@ -164,5 +166,9 @@ void MetaDataHandle<T>::checkPodioDataSvc() {
     std::cout << "Warning: MetaDataHandles require the PodioDataSvc or for compatibility the MetadataSvc" << std::endl;
   }
 }
+} // namespace k4FWCore
+
+template <typename T>
+using MetaDataHandle [[deprecated("Use k4FWCore::MetaDataHandle instead")]] = k4FWCore::MetaDataHandle<T>;
 
 #endif

--- a/k4FWCore/include/k4FWCore/PodioDataSvc.h
+++ b/k4FWCore/include/k4FWCore/PodioDataSvc.h
@@ -31,8 +31,10 @@
 #include "k4FWCore/DataWrapper.h"
 class DataWrapperBase;
 class PodioOutput;
+namespace k4FWCore {
 template <typename T>
 class MetaDataHandle;
+}
 
 /** @class PodioEvtSvc EvtDataSvc.h
  *
@@ -42,7 +44,7 @@ class MetaDataHandle;
  */
 class PodioDataSvc : public DataSvc {
   template <typename T>
-  friend class MetaDataHandle;
+  friend class k4FWCore::MetaDataHandle;
   friend class PodioOutput;
   friend class Lcio2EDM4hepTool;
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
@@ -62,13 +62,14 @@ private:
   Gaudi::Property<int> m_magicNumberOffset{this, "magicNumberOffset", 0,
                                            "Integer to add to the dummy values written to the edm"};
   /// Handle for the genparticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Writer, this};
   /// Handle for the genvertices to be written
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHit", Gaudi::DataHandle::Writer,
-                                                                             this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHit",
+                                                                                       Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer,
-                                                                           this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Writer, this};
 
   /// for testing: write a second TFile by user in an algorithm
   mutable Float_t m_value;

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_AlgorithmWithTFile.h
@@ -29,12 +29,8 @@
 
 #include "podio/UserDataCollection.h"
 
-// datamodel
-namespace edm4hep {
-class MCParticleCollection;
-class SimTrackerHitCollection;
-class SimCaloHit;
-} // namespace edm4hep
+#include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/SimTrackerHitCollection.h"
 
 /** @class k4FWCoreTest_AlgorithmWithTFile
  *  Test producer to check that data can still be written to

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -26,10 +26,7 @@
 
 #include "podio/UserDataCollection.h"
 
-// datamodel
-namespace edm4hep {
-class MCParticleCollection;
-} // namespace edm4hep
+#include "edm4hep/MCParticleCollection.h"
 
 class k4FWCoreTest_CheckExampleEventData : public Gaudi::Algorithm {
 public:

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CheckExampleEventData.h
@@ -47,9 +47,10 @@ private:
   Gaudi::Property<bool> m_keepEventNumberZero{this, "keepEventNumberZero", false,
                                               "Don't add the event number to the dummy values written"};
   /// Handle for the MCParticles to be written
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Reader, this};
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Reader,
-                                                                           this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Reader, this};
 
   mutable int m_event{0};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_CreateExampleEventData.h
@@ -51,19 +51,21 @@ private:
   /// integer to add to the dummy values written to the edm
   Gaudi::Property<int> m_magicNumberOffset{this, "magicNumberOffset", 0,
                                            "Integer to add to the dummy values written to the edm"};
-  mutable DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles", Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHits",
-                                                                             Gaudi::DataHandle::Writer, this};
-  mutable DataHandle<edm4hep::TrackerHit3DCollection> m_TrackerHitHandle{"TrackerHits", Gaudi::DataHandle::Writer,
-                                                                         this};
+  mutable k4FWCore::DataHandle<edm4hep::MCParticleCollection> m_mcParticleHandle{"MCParticles",
+                                                                                 Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitHandle{"SimTrackerHits",
+                                                                                       Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackerHit3DCollection> m_TrackerHitHandle{"TrackerHits",
+                                                                                   Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<edm4hep::TrackCollection> m_trackHandle{"Tracks", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::TrackCollection> m_trackHandle{"Tracks", Gaudi::DataHandle::Writer, this};
 
-  mutable DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat", Gaudi::DataHandle::Writer,
-                                                                           this};
-  mutable DataHandle<edm4hep::ReconstructedParticleCollection> m_recoHandle{"RecoParticles", Gaudi::DataHandle::Writer,
-                                                                            this};
-  mutable DataHandle<edm4hep::RecoMCParticleLinkCollection> m_linkHandle{"Links", Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<podio::UserDataCollection<float>> m_vectorFloatHandle{"VectorFloat",
+                                                                                     Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::ReconstructedParticleCollection> m_recoHandle{"RecoParticles",
+                                                                                      Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::RecoMCParticleLinkCollection> m_linkHandle{"Links", Gaudi::DataHandle::Writer,
+                                                                                   this};
 
   mutable int m_event{0};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -43,8 +43,8 @@ public:
 
 private:
   /// Handle for the SimTrackerHits to be read
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{"SimTrackerHits",
-                                                                                   Gaudi::DataHandle::Reader, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{
+      "SimTrackerHits", Gaudi::DataHandle::Reader, this};
   mutable MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding,
                                                      Gaudi::DataHandle::Reader};
 };

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -45,7 +45,7 @@ private:
   /// Handle for the SimTrackerHits to be read
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{
       "SimTrackerHits", Gaudi::DataHandle::Reader, this};
-  mutable MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding,
-                                                     Gaudi::DataHandle::Reader};
+  mutable k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{
+      m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
 };
 #endif /* K4FWCORE_K4FWCORETEST_CELLID */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -52,8 +52,8 @@ private:
   /// Handle for the SimTrackerHits to be written
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{
       "SimTrackerHits", Gaudi::DataHandle::Writer, this};
-  MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
-                                             Gaudi::DataHandle::Writer};
+  k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
+                                                       Gaudi::DataHandle::Writer};
 
   // Some properties for the configuration metadata
   Gaudi::Property<int> m_intProp{this, "intProp", 42, "An integer property"};

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -50,8 +50,8 @@ public:
 
 private:
   /// Handle for the SimTrackerHits to be written
-  mutable DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{"SimTrackerHits",
-                                                                                   Gaudi::DataHandle::Writer, this};
+  mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{
+      "SimTrackerHits", Gaudi::DataHandle::Writer, this};
   MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
                                              Gaudi::DataHandle::Writer};
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Restrict the `DataHandle` to work only for collections that are from podio generated EDMs
- Remove unnecessary friendship with (deprecated and removed) Gaudi classes
- Bump the minimum required version of podio to 1.3

ENDRELEASENOTES

Another small part that falls out of #318. It looks like there is no usage of the `DataHandle` throughout the stack that is not a podio collection, so we can simply require that at compile time to simplify the implementation where we no longer have to handle other types.

Have we decided on a convention yet on how to use concepts? I have for now gone with constraining them in the template specification directly, but we could also go via the the `requires` route and keeping the `template<typename T>` part.

- [ ] Includes #317 (could be done without that if desired, but there are fewer sources for merge conflicts this way)