### PR TITLE
Remove dead declaration

### DIFF
--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -55,9 +55,6 @@ public:
    */
   void put(T* object);
 
-  // Temporary workaround for k4MarlinWrapper
-  const std::string getCollMetadataCellID(const unsigned int id);
-
   T* put(std::unique_ptr<T> object);
 
   /**


### PR DESCRIPTION
Implementation has been removed in #171


BEGINRELEASENOTES
- Remove the declaration of `DataHandle::getCollMetadataCellID` since the implementation has been removed long ago

ENDRELEASENOTES
