### PR TITLE
Remove unnecessary PodioDataSvc from DataHandle and harmonize constructors

### DIFF
--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -39,7 +39,6 @@ public:
   friend class AlgTool;
 
 public:
-  DataHandle();
   ~DataHandle() override;
 
   /// Initialises mother class

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -25,7 +25,9 @@
 #include <GaudiKernel/DataObjectHandle.h>
 #include <GaudiKernel/ServiceHandle.h>
 
+#include <memory>
 #include <stdexcept>
+#include <string>
 #include <type_traits>
 
 /**

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -41,6 +41,11 @@ public:
   friend class AlgTool;
 
 public:
+  DataHandle() = delete;
+  DataHandle(const DataHandle&) = delete;
+  DataHandle& operator=(const DataHandle&) = delete;
+  DataHandle(DataHandle&&) = default;
+  DataHandle& operator=(DataHandle&&) = default;
   ~DataHandle() override;
 
   DataHandle(const std::string& k, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg);

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -20,11 +20,11 @@
 #define K4FWCORE_DATAHANDLE_H
 
 #include "k4FWCore/DataWrapper.h"
-#include "k4FWCore/PodioDataSvc.h"
-
-#include "GaudiKernel/DataObjectHandle.h"
 
 #include <GaudiKernel/AnyDataWrapper.h>
+#include <GaudiKernel/DataObjectHandle.h>
+#include <GaudiKernel/ServiceHandle.h>
+
 #include <stdexcept>
 #include <type_traits>
 
@@ -64,7 +64,7 @@ public:
 
 private:
   ServiceHandle<IDataProviderSvc> m_eds;
-  T* m_dataPtr;
+  T* m_dataPtr{nullptr};
 };
 
 template <typename T>
@@ -84,13 +84,8 @@ template <typename T>
 DataHandle<T>::DataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)
     : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {
   if (a == Gaudi::DataHandle::Writer) {
-    m_eds.retrieve().ignore();
-    m_dataPtr = nullptr;
-    auto* podio_data_service = dynamic_cast<PodioDataSvc*>(m_eds.get());
-    if (nullptr != podio_data_service) {
-      if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
-        m_dataPtr = new T();
-      }
+    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+      m_dataPtr = new T();
     }
   }
 }

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -43,9 +43,6 @@ public:
 public:
   ~DataHandle() override;
 
-  /// Initialises mother class
-  DataHandle(DataObjID& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg);
-
   DataHandle(const std::string& k, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg);
 
   /// Retrieve object from transient data store
@@ -73,17 +70,6 @@ DataHandle<T>::~DataHandle() {
   // release memory allocated for primitive types (see comments in ctor)
   if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
     delete m_dataPtr;
-  }
-}
-
-//---------------------------------------------------------------------------
-template <typename T>
-DataHandle<T>::DataHandle(DataObjID& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)
-    : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {
-  if (a == Gaudi::DataHandle::Writer) {
-    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
-      m_dataPtr = new T();
-    }
   }
 }
 

--- a/k4FWCore/include/k4FWCore/DataHandle.h
+++ b/k4FWCore/include/k4FWCore/DataHandle.h
@@ -78,7 +78,13 @@ DataHandle<T>::~DataHandle() {
 //---------------------------------------------------------------------------
 template <typename T>
 DataHandle<T>::DataHandle(DataObjID& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)
-    : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {}
+    : DataObjectHandle<DataWrapper<T>>(descriptor, a, fatherAlg), m_eds("EventDataSvc", "DataHandle") {
+  if (a == Gaudi::DataHandle::Writer) {
+    if constexpr (std::is_integral_v<T> || std::is_floating_point_v<T>) {
+      m_dataPtr = new T();
+    }
+  }
+}
 
 template <typename T>
 DataHandle<T>::DataHandle(const std::string& descriptor, Gaudi::DataHandle::Mode a, IDataHandleHolder* fatherAlg)


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the usage of `PodioDataSvc` from the `DataHandle` as it's not necessary
- Harmonize the behavior of the constructors
- Remove the declaration of the unimplemented default constructor

ENDRELEASENOTES

This is another coherent set of changes dropping out of #318 
