### PR TITLE
Explicitly mention source files instead of GLOB

### DIFF
--- a/k4FWCore/CMakeLists.txt
+++ b/k4FWCore/CMakeLists.txt
@@ -28,10 +28,22 @@ target_include_directories(k4FWCore PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
-file(GLOB k4fwcore_plugin_sources components/*.cpp)
 gaudi_add_module(k4FWCorePlugins
-                 SOURCES ${k4fwcore_plugin_sources}
+                 SOURCES
+                   components/CollectionMerger.cpp
+                   components/EventCounter.cpp
+                   components/EventHeaderCreator.cpp
+                   components/FCCDataSvc.cpp
+                   components/IOSvc.cpp
+                   components/MetadataSvc.cpp
+                   components/PodioInput.cpp
+                   components/PodioOutput.cpp
+                   components/Reader.cpp
+                   components/UniqueIDGenSvc.cpp
+                   components/Writer.cpp
+                   components/k4DataSvc.cpp
                  LINK Gaudi::GaudiKernel k4FWCore k4FWCore::k4Interface ROOT::Core ROOT::RIO ROOT::Tree EDM4HEP::edm4hep)
+
 target_include_directories(k4FWCorePlugins PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -17,7 +17,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ]]
 
-file(GLOB k4fwcoretest_plugin_sources src/components/*.cpp)
+set(k4fwcoretest_plugin_sources
+  src/components/ExampleEventHeaderConsumer.cpp
+  src/components/ExampleFunctionalConsumer.cpp
+  src/components/ExampleFunctionalConsumerMultiple.cpp
+  src/components/ExampleFunctionalConsumerRuntimeCollections.cpp
+  src/components/ExampleFunctionalConsumerRuntimeCollectionsMultiple.cpp
+  src/components/ExampleFunctionalFilter.cpp
+  src/components/ExampleFunctionalMetadataConsumer.cpp
+  src/components/ExampleFunctionalMetadataProducer.cpp
+  src/components/ExampleFunctionalProducer.cpp
+  src/components/ExampleFunctionalProducerInt.cpp
+  src/components/ExampleFunctionalProducerMultiple.cpp
+  src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+  src/components/ExampleFunctionalTransformer.cpp
+  src/components/ExampleFunctionalTransformerHist.cpp
+  src/components/ExampleFunctionalTransformerMultiple.cpp
+  src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
+  src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+  src/components/ExampleFunctionalTransformerRuntimeEmpty.cpp
+  src/components/ExampleGaudiFunctionalProducer.cpp
+  src/components/ExampleParticleIDConsumer.cpp
+  src/components/ExampleParticleIDProducer.cpp
+  src/components/ExampleRNGSeedingAlg.cpp
+  src/components/k4FWCoreTest_AlgorithmWithTFile.cpp
+  src/components/k4FWCoreTest_cellID_reader.cpp
+  src/components/k4FWCoreTest_cellID_writer.cpp
+  src/components/k4FWCoreTest_CheckExampleEventData.cpp
+  src/components/k4FWCoreTest_CreateExampleEventData.cpp
+  src/components/k4FWCoreTest_CreateMarlinWrapperCollection.cpp
+  src/components/k4FWCoreTest_HelloWorldAlg.cpp
+  src/components/TestUniqueIDGenSvc.cpp
+  src/components/TypeMisMatchDemo.cpp
+)
 
 gaudi_add_module(k4FWCoreTestPlugins
                  SOURCES ${k4fwcoretest_plugin_sources}

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -27,7 +27,6 @@ set(k4fwcoretest_plugin_sources
   src/components/ExampleFunctionalMetadataConsumer.cpp
   src/components/ExampleFunctionalMetadataProducer.cpp
   src/components/ExampleFunctionalProducer.cpp
-  src/components/ExampleFunctionalProducerInt.cpp
   src/components/ExampleFunctionalProducerMultiple.cpp
   src/components/ExampleFunctionalProducerRuntimeCollections.cpp
   src/components/ExampleFunctionalTransformer.cpp


### PR DESCRIPTION
spack doesn't always re-run cmake when in a development environment leading to failing builds due to left over source file mentions (e.g. when switching branches)


BEGINRELEASENOTES
- Switch from `file(GLOB ...)` to explicitly mention source files for k4FWCore plugin sources

ENDRELEASENOTES
