### PR TITLE
Create a new target to copy the files after all the other targets

### DIFF
--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -71,7 +71,7 @@ endfunction()
 add_custom_target(copy_directory ALL
   COMMAND ${CMAKE_COMMAND} -E copy_directory
           ${PROJECT_SOURCE_DIR}/python/k4FWCore/ ${PROJECT_BINARY_DIR}/k4FWCore/genConfDir/k4FWCore
-  COMMENT "Copying k4FWCore python package after building k4FWCoreTestPlugins"
+  COMMENT "Copying k4FWCore python package after building all the libraries and plugins"
   DEPENDS k4FWCoreTestPlugins k4FWCore k4FWCorePlugins
 )
 


### PR DESCRIPTION
Currently the python folder is copied to a subdirectory in the build tree and this is used for the python imports. The problem is that Gaudi can overwrite the `__init__.py` with an empty file, and then first `k4run` will complain that the `[0]` indexing of the loggers doesn't work, and if that is fixed then it will complain with a weird error.

This is the error about the indexing:
```
32: Traceback (most recent call last):
32:   File "/k4FWCore/k4FWCore/scripts/k4run", line 278, in <module>
32:     main()
32:     ~~~~^^
32:   File "/k4FWCore/k4FWCore/scripts/k4run", line 138, in main
32:     logger.handlers[0].setFormatter(formatter)
32:     ~~~~~~~~~~~~~~~^^^
32: IndexError: list index out of range
```
which is easy to fix, but then
```
32: Traceback (most recent call last):
32:   File "/k4FWCore/k4FWCore/scripts/k4run", line 283, in <module>
32:     main()
32:     ~~~~^^
32:   File "/k4FWCore/k4FWCore/scripts/k4run", line 210, in main
32:     load_file(file)
32:     ~~~~~~~~~^^^^^^
32:   File "k4FWCore/build/k4FWCore/k4FWCore/genConfDir/k4FWCore/utils.py", line 87, in load_file
32:     exec(code, globals())
32:     ~~~~^^^^^^^^^^^^^^^^^
32:   File "<string>", line 31, in <module>
32: TypeError: 'module' object is not callable

```

A way of reproducing it is to build, then comment out one of the files in https://github.com/key4hep/k4FWCore/blob/9e0bcb5e73b8aebc86cb5f67ebf943b0551678c7/k4FWCore/CMakeLists.txt#L33
and then compile again. The file `k4FWCore/genConfDir/k4FWCore/__init__.py` in the build directory will now be empty, and running `ctest` will fail. I have also found these errors consistently in CI one day a few weeks ago (I suspect there is a probability that Gaudi overwrites the file in any build if the order is not the right one).

BEGINRELEASENOTES
- Create a new target to copy the files after all the other targets to prevent errors

ENDRELEASENOTES