### PR TITLE
Do not set properties twice for ApplicationMgr and MessageSvc in the job options

### DIFF
--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -115,14 +115,12 @@ StatusCode PodioOutput::finalize() {
   const auto& jobOptionsSvc = Gaudi::svcLocator()->getOptsSvc();
   const auto& configured_properties = jobOptionsSvc.items();
   for (const auto& per_property : configured_properties) {
-    std::stringstream config_stream;
     // sample output:
     // HepMCToEDMConverter.genparticles = "GenParticles";
     // Note that quotes are added to all property values,
     // which leads to problems with ints, lists, dicts and bools.
     // For these types, the quotes must be removed in postprocessing.
-    config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\"\n";
-    config_data.emplace_back(config_stream.str());
+    config_data.emplace_back(std::get<0>(per_property) + " = \"" + std::get<1>(per_property) + "\"\n");
   }
   // Some default components are not captured by the job option service
   // and have to be traversed like this. Note that Gaudi!577 will improve this.
@@ -131,9 +129,9 @@ StatusCode PodioOutput::finalize() {
     if (!svc.isValid())
       continue;
     for (const auto* property : svc->getProperties()) {
-      std::stringstream config_stream;
-      config_stream << name << "." << property->name() << " = \"" << property->toString() << "\"\n";
-      config_data.emplace_back(config_stream.str());
+      config_data.emplace_back(
+        std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n"
+      );
     }
   }
 

--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -122,16 +122,6 @@ StatusCode PodioOutput::finalize() {
     // For these types, the quotes must be removed in postprocessing.
     config_data.emplace_back(std::get<0>(per_property) + " = \"" + std::get<1>(per_property) + "\"\n");
   }
-  // Some default components are not captured by the job option service
-  // and have to be traversed like this. Note that Gaudi!577 will improve this.
-  for (const auto* name : {"ApplicationMgr", "MessageSvc", "NTupleSvc"}) {
-    auto svc = service<IProperty>(name);
-    if (!svc.isValid())
-      continue;
-    for (const auto* property : svc->getProperties()) {
-      config_data.emplace_back(std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n");
-    }
-  }
 
   // Collect all the metadata
   podio::Frame config_metadata_frame{};

--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -121,20 +121,20 @@ StatusCode PodioOutput::finalize() {
     // Note that quotes are added to all property values,
     // which leads to problems with ints, lists, dicts and bools.
     // For these types, the quotes must be removed in postprocessing.
-    config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\";" << std::endl;
-    config_data.push_back(config_stream.str());
+    config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\"\n";
+    config_data.emplace_back(config_stream.str());
   }
   // Some default components are not captured by the job option service
   // and have to be traversed like this. Note that Gaudi!577 will improve this.
   for (const auto* name : {"ApplicationMgr", "MessageSvc", "NTupleSvc"}) {
-    std::stringstream config_stream;
     auto svc = service<IProperty>(name);
     if (!svc.isValid())
       continue;
     for (const auto* property : svc->getProperties()) {
-      config_stream << name << "." << property->name() << " = \"" << property->toString() << "\";" << std::endl;
+      std::stringstream config_stream;
+      config_stream << name << "." << property->name() << " = \"" << property->toString() << "\"\n";
+      config_data.emplace_back(config_stream.str());
     }
-    config_data.push_back(config_stream.str());
   }
 
   // Collect all the metadata

--- a/k4FWCore/components/PodioOutput.cpp
+++ b/k4FWCore/components/PodioOutput.cpp
@@ -129,9 +129,7 @@ StatusCode PodioOutput::finalize() {
     if (!svc.isValid())
       continue;
     for (const auto* property : svc->getProperties()) {
-      config_data.emplace_back(
-        std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n"
-      );
+      config_data.emplace_back(std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n");
     }
   }
 

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -36,6 +36,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <utility>
 
 class Writer final : public Gaudi::Functional::Consumer<void(const EventContext&)> {
@@ -92,14 +94,12 @@ public:
     // and write it to file as vector of strings
     std::vector<std::string> config_data;
     for (const auto& per_property : Gaudi::svcLocator()->getOptsSvc().items()) {
-      std::stringstream config_stream;
       // sample output:
       // HepMCToEDMConverter.genparticles = "GenParticles"
       // Note that quotes are added to all property values,
       // which leads to problems with ints, lists, dicts and bools.
       // For these types, the quotes must be removed in postprocessing.
-      config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\"\n";
-      config_data.emplace_back(config_stream.str());
+      config_data.emplace_back(std::get<0>(per_property) + " = \"" + std::get<1>(per_property) + "\"\n");
     }
     // Some default components are not captured by the job option service
     // and have to be traversed like this. Note that Gaudi!577 will improve this.
@@ -108,9 +108,7 @@ public:
       if (!svc.isValid())
         continue;
       for (const auto* property : svc->getProperties()) {
-        std::stringstream config_stream;
-        config_stream << name << "." << property->name() << " = \"" << property->toString() << "\"\n";
-        config_data.emplace_back(config_stream.str());
+        config_data.emplace_back(std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n");
       }
     }
 

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -101,16 +101,6 @@ public:
       // For these types, the quotes must be removed in postprocessing.
       config_data.emplace_back(std::get<0>(per_property) + " = \"" + std::get<1>(per_property) + "\"\n");
     }
-    // Some default components are not captured by the job option service
-    // and have to be traversed like this. Note that Gaudi!577 will improve this.
-    for (const auto* name : {"ApplicationMgr", "MessageSvc", "NTupleSvc"}) {
-      auto svc = service<IProperty>(name);
-      if (!svc.isValid())
-        continue;
-      for (const auto* property : svc->getProperties()) {
-        config_data.emplace_back(std::string(name) + "." + property->name() + " = \"" + property->toString() + "\"\n");
-      }
-    }
 
     config_metadata_frame.putParameter("gaudiConfigOptions", config_data);
     if (const char* env_key4hep_stack = std::getenv("KEY4HEP_STACK")) {

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -94,24 +94,24 @@ public:
     for (const auto& per_property : Gaudi::svcLocator()->getOptsSvc().items()) {
       std::stringstream config_stream;
       // sample output:
-      // HepMCToEDMConverter.genparticles = "GenParticles";
+      // HepMCToEDMConverter.genparticles = "GenParticles"
       // Note that quotes are added to all property values,
       // which leads to problems with ints, lists, dicts and bools.
       // For these types, the quotes must be removed in postprocessing.
-      config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\";" << std::endl;
-      config_data.push_back(config_stream.str());
+      config_stream << std::get<0>(per_property) << " = \"" << std::get<1>(per_property) << "\"\n";
+      config_data.emplace_back(config_stream.str());
     }
     // Some default components are not captured by the job option service
     // and have to be traversed like this. Note that Gaudi!577 will improve this.
     for (const auto* name : {"ApplicationMgr", "MessageSvc", "NTupleSvc"}) {
-      std::stringstream config_stream;
       auto svc = service<IProperty>(name);
       if (!svc.isValid())
         continue;
       for (const auto* property : svc->getProperties()) {
-        config_stream << name << "." << property->name() << " = \"" << property->toString() << "\";" << std::endl;
+        std::stringstream config_stream;
+        config_stream << name << "." << property->name() << " = \"" << property->toString() << "\"\n";
+        config_data.emplace_back(config_stream.str());
       }
-      config_data.push_back(config_stream.str());
     }
 
     config_metadata_frame.putParameter("gaudiConfigOptions", config_data);


### PR DESCRIPTION
It seems the options service has all these and it looks like it has had them for a long time. I checked and it's the same properties. For the NTupleSvc, since no one is using it I propose to simply remove them.

BEGINRELEASENOTES
- Do not set properties twice for ApplicationMgr and MessageSvc. Do not write any properties for the NTupleSvc
- Construct strings in place instead of using `std::stringstream`

ENDRELEASENOTES