### PR TITLE
Get the available collections from IOSvc instead of peeking in the file

### DIFF
--- a/k4FWCore/components/IIOSvc.h
+++ b/k4FWCore/components/IIOSvc.h
@@ -40,7 +40,7 @@ public:
    * @return A tuple containing the collections read, the collection names and the frame that owns the collections
    */
   virtual std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next() = 0;
-  virtual std::shared_ptr<std::vector<std::string>> getCollectionNames() const = 0;
+  virtual std::vector<std::string> getAvailableCollections() = 0;
 
   virtual podio::Writer& getWriter() = 0;
   virtual void deleteWriter() = 0;

--- a/k4FWCore/components/IOSvc.cpp
+++ b/k4FWCore/components/IOSvc.cpp
@@ -186,6 +186,14 @@ void IOSvc::handle(const Incident& incident) {
   }
 }
 
+std::vector<std::string> IOSvc::getAvailableCollections() {
+  if (m_reader) {
+    return m_reader->readFrame(podio::Category::Event, m_nextEntry).getAvailableCollections();
+  }
+  throw GaudiException("Reader is not initialized", name(), StatusCode::FAILURE);
+  return {};
+}
+
 bool IOSvc::checkIfWriteCollection(const std::string& collName) { return m_switch.isOn(collName); }
 
 DECLARE_COMPONENT(IOSvc)

--- a/k4FWCore/components/IOSvc.h
+++ b/k4FWCore/components/IOSvc.h
@@ -45,9 +45,7 @@ public:
 
   std::tuple<std::vector<podio::CollectionBase*>, std::vector<std::string>, podio::Frame> next() override;
 
-  std::shared_ptr<std::vector<std::string>> getCollectionNames() const override {
-    return std::make_shared<std::vector<std::string>>(m_collectionNames);
-  }
+  std::vector<std::string> getAvailableCollections() override;
 
 protected:
   Gaudi::Property<std::vector<std::string>> m_collectionNames{

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -229,7 +229,7 @@ add_test_with_env(FunctionalMetadataOldAlgorithm options/ExampleFunctionalMetada
 add_test_with_env(createEventHeaderConcurrent options/createEventHeaderConcurrent.py ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalMetadataReadOldAlgorithm options/ExampleFunctionalMetadataReadOldAlgorithm.py PROPERTIES DEPENDS FunctionalMetadataOldAlgorithm ADD_TO_CHECK_FILES)
 add_test_with_env(FunctionalNonExistingFile options/ExampleFunctionalNonExistingFile.py)
-set_tests_properties(FunctionalNonExistingFile PROPERTIES PASS_REGULAR_EXPRESSION "Failed to open file")
+set_tests_properties(FunctionalNonExistingFile PROPERTIES PASS_REGULAR_EXPRESSION "does not exist")
 add_test_with_env(FunctionalNonExistingFileOverwritten options/ExampleFunctionalNonExistingFile.py --IOSvc.Input functional_producer.root PROPERTIES FIXTURES_REQUIRED ProducerFile)
 add_test_with_env(FunctionalFileTooLong options/ExampleFunctionalFile.py -n 999 --IOSvc.Output toolong.root PROPERTIES FIXTURES_REQUIRED ProducerFile PASS_REGULAR_EXPRESSION
                   "Application Manager Terminated successfully with a user requested ScheduledStop")


### PR DESCRIPTION
when running single-threaded to improve the performance since it's not necessary to read the input file before running to find how many events or which collections exist. This was added in the past because it's needed for running multithreaded. For multithreading a fix has been discussed in Gaudi, because there is not a way to tell the event loop to stop right now because there are no more events, but it will take some time.


BEGINRELEASENOTES
- Get the available collections from IOSvc instead of peeking in the file (if any) before running, improving the performance when running single-threaded (unchanged when running multithreaded)

ENDRELEASENOTES