### PR TITLE
Use . instead of -> for objects that are not pointers

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalProducerRuntimeCollections.cpp
@@ -45,8 +45,8 @@ struct ExampleFunctionalProducerRuntimeCollections final
       }
       info() << "Creating collection " << i << endmsg;
       auto coll = edm4hep::MCParticleCollection();
-      coll->create(1, 2, 3, 4.f, 5.f, 6.f);
-      coll->create(2, 3, 4, 5.f, 6.f, 7.f);
+      coll.create(1, 2, 3, 4.f, 5.f, 6.f);
+      coll.create(2, 3, 4, 5.f, 6.f, 7.f);
       outputCollections.emplace_back(std::move(coll));
     }
     return outputCollections;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollections.cpp
@@ -49,8 +49,8 @@ struct ExampleFunctionalTransformerRuntimeCollections final
       std::string name = "NewMCParticles" + std::to_string(i);
       auto& old_coll = input.at(i);
       auto coll = edm4hep::MCParticleCollection();
-      coll->push_back(old_coll->at(0).clone());
-      coll->push_back(old_coll->at(1).clone());
+      coll.push_back(old_coll->at(0).clone());
+      coll.push_back(old_coll->at(1).clone());
       outputCollections.emplace_back(std::move(coll));
     }
     return outputCollections;

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -188,7 +188,7 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
               << ", " << tracks->at(0).getChi2() << ", " << tracks->at(0).getNdf();
         throw std::runtime_error(error.str());
       }
-      coll->push_back(tracks->at(0).clone());
+      coll.push_back(tracks->at(0).clone());
       trackVecOut.emplace_back(std::move(coll));
     }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Use . instead of -> for objects that are not pointers

ENDRELEASENOTES

It's allowed in podio but I think it's an antipattern, I may propose for it to be removed.