### PR TITLE
Update tests following https://github.com/key4hep/k4-project-template/pull/30

### DIFF
--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -259,10 +259,7 @@ $ENV{PYTHONPATH};\
 "
 )
 get_property(test_names DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY TESTS)
-set_tests_properties(
-  ${test_names}
-  PROPERTIES ENVIRONMENT "${test_environment}"
-)
+set_tests_properties(${test_names} PROPERTIES ENVIRONMENT "${test_environment}")
 
 # The following is done to make the tests work without installing the files in
 # the installation directory. The k4FWCore in the build directory is populated by


### PR DESCRIPTION
BEGINRELEASENOTES
- Update tests following https://github.com/key4hep/k4-project-template/pull/30. In this case, tests were already working without installing

ENDRELEASENOTES