### PR TITLE
Use . instead of -> for objects that are not pointers (part 2)

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerMultiple.cpp
@@ -75,7 +75,7 @@ struct ExampleFunctionalTransformerMultiple final
     for (const auto& p : particles) {
       // We need to create a new particle since the current one is already in a collection
 
-      auto newParticle = newParticlesColl->create();
+      auto newParticle = newParticlesColl.create();
       newParticle.setPDG(p.getPDG() + m_offset);
       newParticle.setGeneratorStatus(p.getGeneratorStatus() + m_offset);
       newParticle.setSimulatorStatus(p.getSimulatorStatus() + m_offset);


### PR DESCRIPTION
Continuation of c6b578c4

BEGINRELEASENOTES
- Use . instead of -> for objects that are not pointers in ExampleFunctionalTransformerMultiple

ENDRELEASENOTES

It seems I missed this file in https://github.com/key4hep/k4FWCore/pull/336