### PR TITLE
Make methods of ICaloReadCrosstalkMap const.

### DIFF
--- a/k4Interface/include/k4Interface/ICaloReadCrosstalkMap.h
+++ b/k4Interface/include/k4Interface/ICaloReadCrosstalkMap.h
@@ -33,7 +33,7 @@ class ICaloReadCrosstalkMap : virtual public IAlgTool {
 public:
   DeclareInterfaceID(ICaloReadCrosstalkMap, 1, 0);
 
-  virtual std::vector<uint64_t> const& getNeighbours(uint64_t cellID) = 0;
-  virtual std::vector<double> const& getCrosstalks(uint64_t cellID) = 0;
+  virtual std::vector<uint64_t> const& getNeighbours(uint64_t cellID) const = 0;
+  virtual std::vector<double> const& getCrosstalks(uint64_t cellID) const = 0;
 };
 #endif /* RECINTERFACE_ICALOREADCROSSTALKMAP_H */


### PR DESCRIPTION
Make ICaloReadCrosstalkMap::getNeighbours and getCrosstalks const.

BEGINRELEASENOTES
- ICaloReadCrosstalkMap migrated to have const methods.
ENDRELEASENOTES
