### PR TITLE
Updates to INoiseCaloCellsTool and INoiseConstTool.

### DIFF
--- a/k4Interface/include/k4Interface/INoiseCaloCellsTool.h
+++ b/k4Interface/include/k4Interface/INoiseCaloCellsTool.h
@@ -34,8 +34,11 @@ class INoiseCaloCellsTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(INoiseCaloCellsTool, 1, 0);
 
-  virtual void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) = 0;
-  virtual void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) = 0;
+  virtual void addRandomCellNoise(std::unordered_map<uint64_t, double>& aCells) const = 0;
+  virtual void filterCellNoise(std::unordered_map<uint64_t, double>& aCells) const = 0;
+
+  virtual void addRandomCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const = 0;
+  virtual void filterCellNoise(std::vector<std::pair<uint64_t, double>>& aCells) const = 0;
 };
 
 #endif /* RECINTERFACE_INOISECALOCELLSTOOL_H */

--- a/k4Interface/include/k4Interface/INoiseConstTool.h
+++ b/k4Interface/include/k4Interface/INoiseConstTool.h
@@ -33,8 +33,8 @@ class INoiseConstTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(INoiseConstTool, 1, 0);
 
-  virtual double getNoiseRMSPerCell(uint64_t aCellID) = 0;
-  virtual double getNoiseOffsetPerCell(uint64_t aCellID) = 0;
+  virtual double getNoiseRMSPerCell(uint64_t aCellID) const = 0;
+  virtual double getNoiseOffsetPerCell(uint64_t aCellID) const = 0;
 };
 
 #endif /* RECINTERFACE_INOISECONSTTOOL_H */


### PR DESCRIPTION
Make INoiseCaloCellsTool::addRandomCellNoise and filterCellNoise as well as INoiseConstTool::getNoiseRMSPerCell and getNoiseRMSPerCell const.

Add new overloads for INoiseCaloCellsTool::addRandomCellNoise and filterCellNoise that operate on a vector of cell/energy pairs rather than a map.

Impementations of these interfaces in k4RecCalorimeter have already been adjusted appropriately:

https://github.com/HEP-FCC/k4RecCalorimeter/pull/177 https://github.com/HEP-FCC/k4RecCalorimeter/pull/183

Clients should not be affected.

BEGINRELEASENOTES
- Updated noise tool interfaces to remove non-const methods and add interfaces that operate on vectors rather than maps.
ENDRELEASENOTES
