### PR TITLE
ICalibrateCaloHitsTool updates.

### DIFF
--- a/k4Interface/include/k4Interface/ICalibrateCaloHitsTool.h
+++ b/k4Interface/include/k4Interface/ICalibrateCaloHitsTool.h
@@ -34,7 +34,8 @@ class ICalibrateCaloHitsTool : virtual public IAlgTool {
 public:
   DeclareInterfaceID(ICalibrateCaloHitsTool, 1, 0);
 
-  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) = 0;
+  virtual void calibrate(std::unordered_map<uint64_t, double>& aHits) const = 0;
+  virtual void calibrate(std::vector<std::pair<uint64_t, double>>& aHits) const = 0;
 };
 
 #endif /* RECINTERFACE_ICALIBRATECALOHITSTOOL_H */


### PR DESCRIPTION
Make methods of ICalibrateCaloHitsTool const.

Add a new calibrate method that takes a vector of hit information rather than a map.

Derived classes implementing this interface in k4RecCalorimeter have been updated:

https://github.com/HEP-FCC/k4RecCalorimeter/pull/186 https://github.com/HEP-FCC/k4RecCalorimeter/pull/178

Clients should not be affected.


BEGINRELEASENOTES
- Make methods of ICalibrateCaloHitsTool const, and add an interface that takes a vector of hit information rather than a map.
ENDRELEASENOTES
