### PR TITLE
Include <variant> where it's used

### DIFF
--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace k4FWCore {
 

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -31,6 +31,7 @@
 #include <stdexcept>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 namespace k4FWCore {
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Include `<variant>` where it's used, introduced in b233ef11

ENDRELEASENOTES