### PR TITLE
Only set the OutputLevel from the command line if one was passed

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -8,6 +8,8 @@ import signal
 import warnings
 from pathlib import Path
 
+from Gaudi import Configuration
+
 from k4FWCore.utils import load_file, get_logger, set_log_level, LOG_LEVELS
 
 # Terminate the process if a SIGPIPE is received
@@ -213,8 +215,6 @@ def main():
     set_log_level(opts[0].log_level or "INFO")
 
     if opts[0].list:
-        from Gaudi import Configuration
-
         cfgdb = Configuration.cfgDb
         logger.info("Available components:\n")
         for item in sorted(cfgdb):
@@ -267,10 +267,16 @@ def main():
         else:
             conf.setProp(optionName.rsplit(".", 1)[1], opts_dict[optionName])
 
-    if opts.verbose:
-        from Gaudi.Configuration import VERBOSE
+    if opts.log_level:
+        try:
+            ApplicationMgr().OutputLevel = getattr(
+                Configuration, logging.getLevelName(logger.level)
+            )
+        except AttributeError:
+            logger.warning(
+                f"{logging.getLevelName(logger.level)} (from log level {logger.level}) is not a valid OutputLevel for Gaudi"
+            )
 
-        ApplicationMgr().OutputLevel = VERBOSE
     if opts.num_events is not None:
         ApplicationMgr().EvtMax = opts.num_events
     # Allow graceful exit with Ctrl + C

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -16,9 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import logging
 
-from Gaudi import Configuration
 from Configurables import ApplicationMgr as AppMgr
 from Configurables import HiveSlimEventLoopMgr
 from Configurables import Reader, Writer, IOSvc, Gaudi__Sequencer, EventLoopMgr
@@ -43,12 +41,6 @@ class ApplicationMgr:
 
     def __init__(self, **kwargs):
         self._mgr = AppMgr(**kwargs)
-        try:
-            self._mgr.OutputLevel = getattr(Configuration, logging.getLevelName(logger.level))
-        except AttributeError:
-            logger.warning(
-                f"{logging.getLevelName(logger.level)} (from log level {logger.level}) is not a valid OutputLevel for Gaudi"
-            )
 
     def _setup_reader(self, reader, iosvc_props):
         """Setup the reader consistently such that it has sane defaults


### PR DESCRIPTION
BEGINRELEASENOTES
- Make sure to only set an `OutputLevel` on the `ApplicationMgr` if `--log-level` has actually been used instead of setting it to `INFO` (regardless of the user configuration in the option file) even if no `--log-level` has passed

ENDRELEASENOTES

This was introduced in #306, from where also the original bug stems. Without this fix even if a user has `OutputLevel=DEBUG` in their option file, we have later reset it to `INFO` because that was the default value for `--log-level`. We should only override values from the option file if users explicitly pass another `--log-level` via the CLI.