### PR TITLE
Fix the construction of details::ReadHandle from Gaudi

### DIFF
--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -307,8 +307,10 @@ namespace details {
     /// @note the use std::enable_if is required to avoid ambiguities
     template <typename OWNER, typename K, typename = std::enable_if_t<std::is_base_of_v<IProperty, OWNER>>>
     FunctionalDataObjectReadHandle(OWNER* owner, std::string propertyName, K key = {}, std::string doc = "")
-        : ::details::ReadHandle<T>(owner, Gaudi::DataHandle::Reader, std::move(propertyName), std::move(key),
-                                   std::move(doc)) {}
+        : ::details::ReadHandle<T>(std::move(key), Gaudi::DataHandle::Reader, owner) {
+      auto p = owner->declareProperty(std::move(propertyName), *this, std::move(doc));
+      p->template setOwnerType<OWNER>();
+    }
 
     template <typename... Args>
     FunctionalDataObjectReadHandle(std::tuple<Args...>&& args)


### PR DESCRIPTION
following https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1856 where a template that we are using (through our version of the FunctionalDataObjectReadHandle) was removed. The change is simply to do the same changes that were done in Gaudi.

BEGINRELEASENOTES
- Fix the construction of details::ReadHandle from Gaudi following the changes in  https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1856 to fix compilation with Gaudi 40.2 when tests are enabled

ENDRELEASENOTES