### PR TITLE
Add missing test forgotten in https://github.com/key4hep/k4FWCore/pull/345

### DIFF
--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -252,6 +252,7 @@ add_test_fwcore(EfficiencyFilter options/ExampleEfficiencyFilter.py PROPERTIES F
 
 add_test_fwcore(FunctionalTransformerInputOutputLocations options/ExampleFunctionalTransformerInputOutputLocations.py)
 add_test_fwcore(FunctionalMultiTransformerInputOutputLocations options/ExampleFunctionalMultiTransformerInputOutputLocations.py)
+add_test_fwcore(FunctionalConsumerInputOutputLocations options/ExampleFunctionalConsumerInputOutputLocations.py)
 
 add_executable(check_ParticleIDOutputs src/check_ParticleIDOutputs.cpp)
 target_link_libraries(check_ParticleIDOutputs PRIVATE podio::podioIO EDM4HEP::edm4hep EDM4HEP::utils fmt::fmt)


### PR DESCRIPTION
BEGINRELEASENOTES
  - Add missing test forgotten in b233ef11c3649ea2213f74be169d59cc80d49999 (https://github.com/key4hep/k4FWCore/pull/345)

ENDRELEASENOTES
  
Since the consumer is an independent class, it's good there is a test only for it.