### PR TITLE
Fix using DataHandles of types that are not collections with IOSvc

### DIFF
--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -163,6 +163,11 @@ public:
       } else {
         // Things stored via DataHandles need special casing
         if (const auto oldColl = dynamic_cast<DataWrapperBase*>(pReg->object())) {
+          if (!oldColl->collectionBase()) {
+            debug() << collName << " does not have a valid CollectionBase. " << collName << " will be skipped."
+                    << endmsg;
+            continue;
+          }
           collType = oldColl->collectionBase()->getTypeName();
         }
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix crash when running with IOSvc and DataHandles of types that are not collections.

ENDRELEASENOTES
  
An example is `GenAlg`: https://github.com/HEP-FCC/k4Gen/blob/main/k4Gen/src/components/GenAlg.h#L45 that will put a `DataWrapper<HepMC3::GenEvent>` in the store. This will crash because `collectionBase()` returns a `nullptr` when the type is not a collection: https://github.com/key4hep/k4FWCore/blob/main/k4FWCore/include/k4FWCore/DataWrapper.h#L86