### PR TITLE
Make sure we can consume EDM4hep 1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,10 @@ set(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_
 find_package(ROOT COMPONENTS RIO Tree REQUIRED)
 find_package(Gaudi REQUIRED)
 find_package(podio 1.3 REQUIRED)
-find_package(EDM4HEP 0.99 REQUIRED)
+find_package(EDM4HEP 1.0)
+if (NOT EDM4HEP_FOUND)
+  find_package(EDM4HEP 0.99 REQUIRED)
+endif()
 find_package(fmt REQUIRED)
 
 include(cmake/Key4hepConfig.cmake)


### PR DESCRIPTION
BEGINRELEASENOTES
- Ensure we can still configure and build with EDM4hep 1.0

ENDRELEASENOTES
