### PR TITLE
Fix escaping '%' for the help messages with Python 3.14

### DIFF
--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -112,7 +112,9 @@ def add_arguments(parser, app_mgr):
                 f"--{propName}",
                 f"--{propNameReversed}",
                 type=proptype,
-                help=prop_value[1].replace('%', '%%').strip(), # Python 3.14 complains about single '%' in help strings
+                help=prop_value[1]
+                .replace("%", "%%")  # Python 3.14 complains about single '%' in help strings
+                .strip(),
                 nargs=args,
                 default=value,
             )


### PR DESCRIPTION
With Python 3.14 (3.14.2), if the help message in argparse contains a single `%` it complains:
``` python
$ k4run ExampleEfficiencyFilter.py
Traceback (most recent call last):
  File "/usr/lib/python3.14/argparse.py", line 1747, in _check_help
    formatter._expand_help(action)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.14/argparse.py", line 678, in _expand_help
    return help_string % params
           ~~~~~~~~~~~~^~~~~~~~
TypeError: %c requires an int or a unicode character, not dict

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/k4FWCore/install/bin/k4run", line 310, in <module>
    main()
    ~~~~^^
  File "/k4FWCore/install/bin/k4run", line 234, in main
    option_db = add_arguments(parser, ApplicationMgr())
  File "/k4FWCore/install/bin/k4run", line 111, in add_arguments
    parser.add_argument(
    ~~~~~~~~~~~~~~~~~~~^
        f"--{propName}",
        ^^^^^^^^^^^^^^^^
    ...<4 lines>...
        default=value,
        ^^^^^^^^^^^^^^
    )
    ^
  File "/usr/lib/python3.14/argparse.py", line 1561, in add_argument
    self._check_help(action)
    ~~~~~~~~~~~~~~~~^^^^^^^^
  File "/usr/lib/python3.14/argparse.py", line 1749, in _check_help
    raise ValueError('badly formed help string') from exc
ValueError: badly formed help string
```

so another `%` has to be added to escape it. 


BEGINRELEASENOTES
- Turn `%` into `%%` in the argparse help of `k4run` to avoid a python error in `EfficiencyFilter.cpp`.

ENDRELEASENOTES