### PR TITLE
Add indexer method to ICalorimeterTool.

### DIFF
--- a/k4Interface/include/k4Interface/ICaloIndexer.h
+++ b/k4Interface/include/k4Interface/ICaloIndexer.h
@@ -27,7 +27,6 @@
 #define K4INTERFACE_ICALOINDEXER_H
 
 #include <cstdint>
-#include <memory>
 #include <span>
 
 /**

--- a/k4Interface/include/k4Interface/ICalorimeterTool.h
+++ b/k4Interface/include/k4Interface/ICalorimeterTool.h
@@ -24,6 +24,8 @@
 // Gaudi
 #include "GaudiKernel/IAlgTool.h"
 
+#include <memory>
+
 /** @class ICalorimeterTool RecInterface/RecInterface/ICalorimeterTool.h ICalorimeterTool.h
  *
  *  Abstract interface to calorimeter geometry tool


### PR DESCRIPTION
Add an indexer() method to ICalorimeterTool, which returns a pointer to a new ICaloIndexer object.  This provides an interface for translating cellIDs to indices.

BEGINRELEASENOTES
- Add ICaloIndexer and ICalorimeterTool::indexer().
ENDRELEASENOTES
