### PR TITLE
remove compatibility with older Gaudi histograms

### DIFF
--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerHist.cpp
@@ -25,22 +25,10 @@
 
 #include <string>
 
-#include "GAUDI_VERSION.h"
-
-#if GAUDI_MAJOR_VERSION < 39
-namespace Gaudi::Accumulators {
-template <unsigned int ND, atomicity Atomicity = atomicity::full, typename Arithmetic = double>
-using StaticRootHistogram =
-    Gaudi::Accumulators::RootHistogramingCounterBase<ND, Atomicity, Arithmetic, naming::histogramString>;
-}
-#endif
-
 struct ExampleFunctionalTransformerHist final
     : k4FWCore::Transformer<edm4hep::MCParticleCollection(const edm4hep::MCParticleCollection& input)> {
   StatusCode initialize() override {
-#if GAUDI_MAJOR_VERSION >= 39
     m_customHistogram.createHistogram(*this);
-#endif
     return StatusCode::SUCCESS;
   }
   // The pairs in KeyValues can be changed from python and they correspond
@@ -53,9 +41,7 @@ struct ExampleFunctionalTransformerHist final
   edm4hep::MCParticleCollection operator()(const edm4hep::MCParticleCollection& input) const override {
     // Fill the histogram with the energy of one particle
     ++m_histogram[input[0 + !m_firstParticle.value()].getEnergy()];
-#if GAUDI_MAJOR_VERSION >= 39
     ++m_customHistogram[input[0 + !m_firstParticle.value()].getEnergy()];
-#endif
     // Return an empty collection since we don't care about the collection
     return {};
   }
@@ -66,12 +52,10 @@ private:
       this, "Histogram Name", "Histogram Title", {100, 0, 10.}};
 
 public:
-#if GAUDI_MAJOR_VERSION >= 39
   // This is a histogram with title, name and bins that can be set from python
   // The callback function is only needed for these histograms with configurable properties
   void registerCallBack(Gaudi::StateMachine::Transition, std::function<void()>) {}
   mutable Gaudi::Accumulators::RootHistogram<1> m_customHistogram{this, "CustomHistogram"};
-#endif
 
   Gaudi::Property<bool> m_firstParticle{this, "FirstParticle", true};
 };


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove histogram interface compatibility with Gaudi versions older that v39

ENDRELEASENOTES

Both the nigthlies and the current release (2026-02-01) have Gaudi  newer than 39.