### PR TITLE
Make it posssible to set metadata also from Tools

### DIFF
--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -41,7 +41,7 @@ concept Streamable = requires(std::ostream& os, const T& v) {
 ///             parameter, typically "this"
 /// @tparam GaudiComp The type of the component. This will be deduced in
 ///                   pretty much all of the use cases
-template <typename T, typename GaudiComp = Gaudi::Algorithm>
+template <typename T, typename GaudiComp>
 void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
   comp->debug() << "Trying to put parameter '" << name << "'";
   if constexpr (Streamable<T>) {
@@ -77,7 +77,7 @@ putParameter(const std::string& name, const T& value) {
 /// @tparam GaudiComp The type of the component. This will be deduced in
 ///                   pretty much all of the use cases
 /// @return std::optional<T> The value of the parameter, if it exists or std::nullopt
-template <typename T, typename GaudiComp = Gaudi::Algorithm>
+template <typename T, typename GaudiComp>
 std::optional<T> getParameter(const std::string& name, const GaudiComp* comp) {
   comp->debug() << "Trying to get parameter '" << name << "'" << endmsg;
   auto metadataSvc = comp->template service<IMetadataSvc>("MetadataSvc", false);

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -19,25 +19,29 @@
 #ifndef FWCORE_METADATAUTILS_H
 #define FWCORE_METADATAUTILS_H
 
-#include "Gaudi/Algorithm.h"
+#include "k4FWCore/IMetadataSvc.h"
+
+#include <Gaudi/Algorithm.h>
 #include <GaudiKernel/Service.h>
 
-#include "k4FWCore/IMetadataSvc.h"
 
 namespace k4FWCore {
 
 /// @brief Save a metadata parameter in the metadata frame
 /// @param name The name of the parameter
 /// @param value The value of the parameter
-/// @param alg The algorithm that is saving the parameter, typically "this"
-template <typename T>
-void putParameter(const std::string& name, const T& value, const Gaudi::Algorithm* alg) {
-  auto metadataSvc = alg->service<IMetadataSvc>("MetadataSvc", false);
+/// @param comp The Gaudi component (algorithm, tool) that is saving the
+///             parameter, typically "this"
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+template <typename T, typename GaudiComp = Gaudi::Algorithm>
+void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
+  auto metadataSvc = comp->template service<IMetadataSvc>("MetadataSvc", false);
   if (!metadataSvc) {
-    alg->error() << "MetadataSvc not found" << endmsg;
+    comp->error() << "MetadataSvc not found" << endmsg;
     return;
   }
-  metadataSvc->put<T>(name, value);
+  metadataSvc->template put<T>(name, value);
 }
 
 /// @brief Save a metadata parameter in the metadata frame. Overload for compatibility
@@ -56,16 +60,19 @@ putParameter(const std::string& name, const T& value) {
 
 /// @brief Get a metadata parameter from the metadata frame
 /// @param name The name of the parameter
-/// @param alg The algorithm that is saving the parameter, typically "this"
+/// @param comp The Gaudi component (algorithm, tool) that is retrieving the
+///             parameter, typically "this"
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
 /// @return std::optional<T> The value of the parameter, if it exists or std::nullopt
-template <typename T>
-std::optional<T> getParameter(const std::string& name, const Gaudi::Algorithm* alg) {
-  auto metadataSvc = alg->service<IMetadataSvc>("MetadataSvc", false);
+template <typename T, typename GaudiComp = Gaudi::Algorithm>
+std::optional<T> getParameter(const std::string& name, const GaudiComp* comp) {
+  auto metadataSvc = comp->template service<IMetadataSvc>("MetadataSvc", false);
   if (!metadataSvc) {
-    alg->error() << "MetadataSvc not found" << endmsg;
+    comp->error() << "MetadataSvc not found" << endmsg;
     return std::nullopt;
   }
-  return metadataSvc->get<T>(name);
+  return metadataSvc->template get<T>(name);
 }
 
 /// @brief Get a metadata parameter from the metadata frame. Overload for compatibility

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -24,8 +24,19 @@
 #include <Gaudi/Algorithm.h>
 #include <GaudiKernel/Service.h>
 
+#include <ostream>
+#include <type_traits>
 
 namespace k4FWCore {
+
+namespace detail {
+  template <typename T, typename = void>
+  struct is_streamable : std::false_type {};
+
+  template <typename T>
+  struct is_streamable<T, std::void_t<decltype(std::declval<std::ostream&>() << std::declval<const T&>())>>
+      : std::true_type {};
+} // namespace detail
 
 /// @brief Save a metadata parameter in the metadata frame
 /// @param name The name of the parameter
@@ -36,6 +47,11 @@ namespace k4FWCore {
 ///                   pretty much all of the use cases
 template <typename T, typename GaudiComp = Gaudi::Algorithm>
 void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
+  comp->debug() << "Trying to put parameter '" << name << "'";
+  if constexpr (detail::is_streamable<T>::value) {
+    comp->debug() << " (value = " << value << ")";
+  }
+  comp->debug() << endmsg;
   auto metadataSvc = comp->template service<IMetadataSvc>("MetadataSvc", false);
   if (!metadataSvc) {
     comp->error() << "MetadataSvc not found" << endmsg;
@@ -67,6 +83,7 @@ putParameter(const std::string& name, const T& value) {
 /// @return std::optional<T> The value of the parameter, if it exists or std::nullopt
 template <typename T, typename GaudiComp = Gaudi::Algorithm>
 std::optional<T> getParameter(const std::string& name, const GaudiComp* comp) {
+  comp->debug() << "Trying to get parameter '" << name << "'" << endmsg;
   auto metadataSvc = comp->template service<IMetadataSvc>("MetadataSvc", false);
   if (!metadataSvc) {
     comp->error() << "MetadataSvc not found" << endmsg;

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -24,6 +24,7 @@
 #include <Gaudi/Algorithm.h>
 #include <GaudiKernel/Service.h>
 
+#include <optional>
 #include <ostream>
 
 namespace k4FWCore {

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -25,18 +25,13 @@
 #include <GaudiKernel/Service.h>
 
 #include <ostream>
-#include <type_traits>
 
 namespace k4FWCore {
 
-namespace detail {
-  template <typename T, typename = void>
-  struct is_streamable : std::false_type {};
-
-  template <typename T>
-  struct is_streamable<T, std::void_t<decltype(std::declval<std::ostream&>() << std::declval<const T&>())>>
-      : std::true_type {};
-} // namespace detail
+template <typename T>
+concept Streamable = requires(std::ostream& os, const T& v) {
+  { os << v } -> std::convertible_to<std::ostream&>;
+};
 
 /// @brief Save a metadata parameter in the metadata frame
 /// @param name The name of the parameter
@@ -48,7 +43,7 @@ namespace detail {
 template <typename T, typename GaudiComp = Gaudi::Algorithm>
 void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
   comp->debug() << "Trying to put parameter '" << name << "'";
-  if constexpr (detail::is_streamable<T>::value) {
+  if constexpr (Streamable<T>) {
     comp->debug() << " (value = " << value << ")";
   }
   comp->debug() << endmsg;


### PR DESCRIPTION
BEGINRELEASENOTES
- Generalize the `k4FWCore::putParameter` and `k4FWCore::getParameter` functions to also work with Gaudi components other than Algorithms (e.g. `AlgTool`s).
- Add slightly more debug output to these functions

ENDRELEASENOTES

- [x] Includes #389 
