### PR TITLE
Add more utility functions for setting collection level parameters

### DIFF
--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -105,6 +105,27 @@ getParameter(const std::string& name) {
   return metadataSvc->get<T>(name);
 }
 
+/// @brief Put a metadata parameter associated with a collection into the metadata
+///
+/// Internally builds the correct parameter name from the collection name and
+/// parameter name and then stores the value into the metadata frame via the
+/// MetadataSvc
+///
+/// @param collName The name of the collection to which the parameter should be
+///        associated
+/// @param paramName The name of the parameter
+/// @param value The value of the parameter
+/// @param comp The Gaudi component (algorithm, tool) that is saving the
+///             parameter, typically "this"
+/// @tparam T The type of the parameter value
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+template <typename T, typename GaudiComp = Gaudi::Algorithm>
+void putCollectionParameter(const std::string& collName, const std::string& paramName, const T& value,
+                            const GaudiComp* comp) {
+  putParameter(podio::collMetadataParamName(collName, paramName), value, comp);
+}
+
 /// @brief Put the CellID encoding string for a collection into the metadata
 ///
 /// Internally builds the correct parameter name and then stores the encoding
@@ -137,6 +158,27 @@ void putCellIDEncoding(const std::string& collName, const std::string& encoding,
 template <typename GaudiComp = Gaudi::Algorithm>
 std::optional<std::string> getCellIDEncoding(const std::string& collName, const GaudiComp* comp) {
   return getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::CellIDEncoding), comp);
+}
+
+/// @brief Get a metadata parameter associated with a collection from the metadata
+///
+/// Internally builds the correct parameter name from the collection name and
+/// parameter name and then retrieves the value from the metadata frame via the
+/// MetadataSvc
+///
+/// @param collName The name of the collection for which the parameter should be
+///                 retrieved
+/// @param paramName The name of the parameter
+/// @param comp The Gaudi component (algorithm, tool) that is retrieving the
+///             parameter, typically "this"
+/// @tparam T The type of the parameter value
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+/// @return The parameter value if it has been found or std::nullopt if not
+template <typename T, typename GaudiComp = Gaudi::Algorithm>
+std::optional<T> getCollectionParameter(const std::string& collName, const std::string& paramName,
+                                        const GaudiComp* comp) {
+  return getParameter<T>(podio::collMetadataParamName(collName, paramName), comp);
 }
 
 } // namespace k4FWCore

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -24,6 +24,10 @@
 #include <Gaudi/Algorithm.h>
 #include <GaudiKernel/Service.h>
 
+#include <podio/FrameCategories.h>
+
+#include <edm4hep/Constants.h>
+
 #include <optional>
 #include <ostream>
 
@@ -100,6 +104,41 @@ getParameter(const std::string& name) {
   }
   return metadataSvc->get<T>(name);
 }
+
+/// @brief Put the CellID encoding string for a collection into the metadata
+///
+/// Internally builds the correct parameter name and then stores the encoding
+/// into the metadata frame via the MetadataSvc
+///
+/// @param collName The name of the collection to which the encoding should be
+///        associated
+/// @param encoding The cell ID encoding string
+/// @param comp The Gaudi component (algorithm, tool) that is saving the
+///             parameter, typically "this"
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+template <typename GaudiComp = Gaudi::Algorithm>
+void putCellIDEncoding(const std::string& collName, const std::string& encoding, const GaudiComp* comp) {
+  putParameter(podio::collMetadataParamName(collName, edm4hep::labels::CellIDEncoding), encoding, comp);
+}
+
+/// @brief Get the CellID encoding string for a collection from the metadata
+///
+/// Internally builds the correct parameter name and then retrieves the encoding
+/// from the metadata frame via the MetadataSvc
+///
+/// @param collName The name of the collection for which the encoding should be
+///                 retrieved
+/// @param comp The Gaudi component (algorithm, tool) that is retrieving the
+///             encoding, typically "this"
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+/// @return  The encoding string if it has been found or std::nullopt if not
+template <typename GaudiComp = Gaudi::Algorithm>
+std::optional<std::string> getCellIDEncoding(const std::string& collName, const GaudiComp* comp) {
+  return getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::CellIDEncoding), comp);
+}
+
 } // namespace k4FWCore
 
 #endif // FWCORE_METADATAUTILS_H

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -140,24 +140,7 @@ void putCollectionParameter(const std::string& collName, const std::string& para
 ///                   pretty much all of the use cases
 template <typename GaudiComp = Gaudi::Algorithm>
 void putCellIDEncoding(const std::string& collName, const std::string& encoding, const GaudiComp* comp) {
-  putParameter(podio::collMetadataParamName(collName, edm4hep::labels::CellIDEncoding), encoding, comp);
-}
-
-/// @brief Get the CellID encoding string for a collection from the metadata
-///
-/// Internally builds the correct parameter name and then retrieves the encoding
-/// from the metadata frame via the MetadataSvc
-///
-/// @param collName The name of the collection for which the encoding should be
-///                 retrieved
-/// @param comp The Gaudi component (algorithm, tool) that is retrieving the
-///             encoding, typically "this"
-/// @tparam GaudiComp The type of the component. This will be deduced in
-///                   pretty much all of the use cases
-/// @return  The encoding string if it has been found or std::nullopt if not
-template <typename GaudiComp = Gaudi::Algorithm>
-std::optional<std::string> getCellIDEncoding(const std::string& collName, const GaudiComp* comp) {
-  return getParameter<std::string>(podio::collMetadataParamName(collName, edm4hep::labels::CellIDEncoding), comp);
+  putCollectionParameter(collName, edm4hep::labels::CellIDEncoding, encoding, comp);
 }
 
 /// @brief Get a metadata parameter associated with a collection from the metadata
@@ -179,6 +162,23 @@ template <typename T, typename GaudiComp = Gaudi::Algorithm>
 std::optional<T> getCollectionParameter(const std::string& collName, const std::string& paramName,
                                         const GaudiComp* comp) {
   return getParameter<T>(podio::collMetadataParamName(collName, paramName), comp);
+}
+
+/// @brief Get the CellID encoding string for a collection from the metadata
+///
+/// Internally builds the correct parameter name and then retrieves the encoding
+/// from the metadata frame via the MetadataSvc
+///
+/// @param collName The name of the collection for which the encoding should be
+///                 retrieved
+/// @param comp The Gaudi component (algorithm, tool) that is retrieving the
+///             encoding, typically "this"
+/// @tparam GaudiComp The type of the component. This will be deduced in
+///                   pretty much all of the use cases
+/// @return  The encoding string if it has been found or std::nullopt if not
+template <typename GaudiComp = Gaudi::Algorithm>
+std::optional<std::string> getCellIDEncoding(const std::string& collName, const GaudiComp* comp) {
+  return getCollectionParameter<std::string>(collName, edm4hep::labels::CellIDEncoding, comp);
 }
 
 } // namespace k4FWCore

--- a/test/k4FWCoreTest/options/createExampleEventData_cellID.py
+++ b/test/k4FWCoreTest/options/createExampleEventData_cellID.py
@@ -19,7 +19,11 @@
 from Gaudi.Configuration import INFO
 
 from Configurables import k4DataSvc
-from Configurables import k4FWCoreTest_cellID_writer, k4FWCoreTest_cellID_reader
+from Configurables import (
+    k4FWCoreTest_cellID_writer,
+    k4FWCoreTest_cellID_reader,
+    MetadataSvc,
+)
 from Configurables import PodioOutput
 from k4FWCore import ApplicationMgr
 
@@ -49,7 +53,7 @@ ApplicationMgr(
     TopAlg=[producer, consumer, out],
     EvtSel="NONE",
     EvtMax=10,
-    ExtSvc=[podioevent],
+    ExtSvc=[podioevent, MetadataSvc()],
     OutputLevel=INFO,
     StopOnSignal=True,
 )

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataConsumer.cpp
@@ -55,6 +55,17 @@ struct ExampleFunctionalMetadataConsumer final : k4FWCore::Consumer<void(const e
       error() << "MetadataString expected to be 'hello' but is '" << m_metadataString << "'" << endmsg;
       return StatusCode::FAILURE;
     }
+    const auto collIntParam = k4FWCore::getCollectionParameter<int>("MCParticles", "CollectionIntParam", this);
+    if (!collIntParam.has_value() || collIntParam.value() != 42) {
+      error() << "CollectionIntParam expected to be 42 but got " << collIntParam.value_or(-1) << endmsg;
+      return StatusCode::FAILURE;
+    }
+    const auto cellIDEncoding = k4FWCore::getCellIDEncoding("MCParticles", this);
+    if (!cellIDEncoding.has_value() || cellIDEncoding.value() != "system:8,layer:4,module:8") {
+      error() << "CellIDEncoding expected to be 'system:8,layer:4,module:8' but got '"
+              << cellIDEncoding.value_or("<missing>") << "'" << endmsg;
+      return StatusCode::FAILURE;
+    }
     return StatusCode::SUCCESS;
   }
 
@@ -96,6 +107,17 @@ struct ExampleFunctionalMetadataConsumer final : k4FWCore::Consumer<void(const e
     auto finalizeMetadataInt = k4FWCore::getParameter<int>("FinalizeMetadataInt", this).value_or(-1);
     if (finalizeMetadataInt != 10) {
       error() << "FinalizeMetadataInt expected to be 10 but is " << finalizeMetadataInt << endmsg;
+      return StatusCode::FAILURE;
+    }
+    const auto collIntParam = k4FWCore::getCollectionParameter<int>("MCParticles", "CollectionIntParam", this);
+    if (!collIntParam.has_value() || collIntParam.value() != 42) {
+      error() << "CollectionIntParam expected to be 42 but got " << collIntParam.value_or(-1) << endmsg;
+      return StatusCode::FAILURE;
+    }
+    const auto cellIDEncoding = k4FWCore::getCellIDEncoding("MCParticles", this);
+    if (!cellIDEncoding.has_value() || cellIDEncoding.value() != "system:8,layer:4,module:8") {
+      error() << "CellIDEncoding expected to be 'system:8,layer:4,module:8' but got '"
+              << cellIDEncoding.value_or("<missing>") << "'" << endmsg;
       return StatusCode::FAILURE;
     }
 

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
@@ -36,6 +36,8 @@ struct ExampleFunctionalMetadataProducer final : k4FWCore::Producer<edm4hep::MCP
     k4FWCore::putParameter("ParticleTime", m_particleTime.value(), this);
     k4FWCore::putParameter("PDGValues", m_PDGValues.value(), this);
     k4FWCore::putParameter("MetadataString", m_metadataString.value(), this);
+    k4FWCore::putCollectionParameter("MCParticles", "CollectionIntParam", 42, this);
+    k4FWCore::putCellIDEncoding("MCParticles", "system:8,layer:4,module:8", this);
     return StatusCode::SUCCESS;
   }
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.cpp
@@ -19,6 +19,8 @@
 #include "k4FWCoreTest_cellID_reader.h"
 #include "k4FWCoreTest_cellID_writer.h"
 
+#include <k4FWCore/MetadataUtils.h>
+
 DECLARE_COMPONENT(k4FWCoreTest_cellID_reader)
 
 k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName, ISvcLocator* aSvcLoc)
@@ -32,22 +34,15 @@ k4FWCoreTest_cellID_reader::k4FWCoreTest_cellID_reader(const std::string& aName,
 StatusCode k4FWCoreTest_cellID_reader::execute(const EventContext&) const {
   [[maybe_unused]] const auto simtrackerhits_coll = m_simTrackerHitReaderHandle.get();
 
-  const auto cellIDstr = m_cellIDHandle.get();
-
-  if (cellIDstr != cellIDtest) {
-    error() << "ERROR cellID is: " << cellIDstr << "expected (" << cellIDtest << ")" << endmsg;
-    return StatusCode::FAILURE;
-  }
-
-  auto optCellIDstr = m_cellIDHandle.get_optional();
+  const auto optCellIDstr = k4FWCore::getCellIDEncoding(m_simTrackerHitReaderHandle.objKey(), this);
 
   if (!optCellIDstr.has_value()) {
     error() << "ERROR: cellID is empty but was expected to hold a value" << endmsg;
     return StatusCode::FAILURE;
   }
 
-  if (optCellIDstr.value() != cellIDstr) {
-    error() << "ERROR: metadata accessed with by optional and value differs" << endmsg;
+  if (optCellIDstr.value() != cellIDtest) {
+    error() << "ERROR cellID is: " << optCellIDstr.value() << " expected (" << cellIDtest << ")" << endmsg;
     return StatusCode::FAILURE;
   }
 

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_reader.h
@@ -24,9 +24,6 @@
 
 // key4hep
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
-
-#include "edm4hep/Constants.h"
 
 #include "edm4hep/SimTrackerHitCollection.h"
 
@@ -45,7 +42,5 @@ private:
   /// Handle for the SimTrackerHits to be read
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitReaderHandle{
       "SimTrackerHits", Gaudi::DataHandle::Reader, this};
-  mutable k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{
-      m_simTrackerHitReaderHandle, edm4hep::labels::CellIDEncoding, Gaudi::DataHandle::Reader};
 };
 #endif /* K4FWCORE_K4FWCORETEST_CELLID */

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.cpp
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 #include "k4FWCoreTest_cellID_writer.h"
+#include "k4FWCore/MetadataUtils.h"
 
 DECLARE_COMPONENT(k4FWCoreTest_cellID_writer)
 
@@ -32,7 +33,8 @@ StatusCode k4FWCoreTest_cellID_writer::initialize() {
   if (Gaudi::Algorithm::initialize().isFailure()) {
     return StatusCode::FAILURE;
   }
-  m_cellIDHandle.put(cellIDtest);
+
+  k4FWCore::putCellIDEncoding(m_simTrackerHitWriterHandle.objKey(), cellIDtest, this);
 
   return StatusCode::SUCCESS;
 }

--- a/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
+++ b/test/k4FWCoreTest/src/components/k4FWCoreTest_cellID_writer.h
@@ -24,9 +24,6 @@
 
 // key4hep
 #include "k4FWCore/DataHandle.h"
-#include "k4FWCore/MetaDataHandle.h"
-
-#include "edm4hep/Constants.h"
 
 // datamodel
 #include "edm4hep/SimTrackerHitCollection.h"
@@ -52,8 +49,6 @@ private:
   /// Handle for the SimTrackerHits to be written
   mutable k4FWCore::DataHandle<edm4hep::SimTrackerHitCollection> m_simTrackerHitWriterHandle{
       "SimTrackerHits", Gaudi::DataHandle::Writer, this};
-  k4FWCore::MetaDataHandle<std::string> m_cellIDHandle{m_simTrackerHitWriterHandle, edm4hep::labels::CellIDEncoding,
-                                                       Gaudi::DataHandle::Writer};
 
   // Some properties for the configuration metadata
   Gaudi::Property<int> m_intProp{this, "intProp", 42, "An integer property"};


### PR DESCRIPTION
BEGINRELEASENOTES
- Add `k4FWCore::putCollectionParameter` and `k4FWCore::getCollectionParameter` to facilitate setting and getting collection level parameters / metadata
- Add `k4FWCore::putCellIDEncoding` and `k4FWCore::getCellIDEncoding` to facilitate setting and getting CellID encoding strings
- Adapt some tests to use these instead of `MetaDataHandle`s

ENDRELEASENOTES

- [x] Includes #390 
- [x] Includes #389 

These simply wrap `(get|put)Parameter`, but call `podio::collMetadataParamName` (with `edm4hep::labels::CellIDEncoding`) under the hood first before passing things on. This is a follow up on [this discussion](https://github.com/key4hep/k4SimGeant4/pull/89#discussion_r2685382218).

@jmcarcell it looks like currently the only test for CellID encoding goes through a non-functional algorithm. I think we should add one for functional algorithms as well. Do you have a preference on whether
- I should add a completely new Functional algorithm for this, or
- I should re-use an existing one (e.g. the `ExampleFunctionalProducerMultiple`)?
