### PR TITLE
Add support for CMAKE_UNITY_BUILD

### DIFF
--- a/k4FWCore/components/UniqueIDGenSvc.cpp
+++ b/k4FWCore/components/UniqueIDGenSvc.cpp
@@ -18,9 +18,9 @@
  */
 #include "UniqueIDGenSvc.h"
 
-#include <fmt/core.h>
 
 #include <cstddef>
+#include <format>
 #include <stdexcept>
 #include <string>
 
@@ -62,7 +62,7 @@ size_t UniqueIDGenSvc::getUniqueID(event_num_t evt_num, run_num_t run_num, const
     if (!inserted) {
       const auto& [id_evt, id_run, id_name] = it->second;
       throw std::runtime_error(
-          fmt::format("Duplicate ID for event number, run number and algorithm name: {}, {}, \"{}\". "
+          std::format("Duplicate ID for event number, run number and algorithm name: {}, {}, \"{}\". "
                       "ID already assigned to: {}, {}, \"{}\"",
                       evt_num, run_num, name, id_evt, id_run, id_name));
     }

--- a/k4FWCore/components/UniqueIDGenSvc.cpp
+++ b/k4FWCore/components/UniqueIDGenSvc.cpp
@@ -18,7 +18,6 @@
  */
 #include "UniqueIDGenSvc.h"
 
-
 #include <cstddef>
 #include <format>
 #include <stdexcept>

--- a/k4FWCore/include/k4FWCore/FunctionalUtils.h
+++ b/k4FWCore/include/k4FWCore/FunctionalUtils.h
@@ -34,8 +34,7 @@
 
 // #include "GaudiKernel/CommonMessaging.h"
 
-#include <fmt/format.h>
-
+#include <format>
 #include <memory>
 #include <tuple>
 #include <type_traits>
@@ -199,7 +198,7 @@ namespace details {
             inputVector.push_back(typedCollection);
           } else {
             throw GaudiException(
-                fmt::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
+                std::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
                             handle.objKey(), typeid(EDM4hepType).name(),
                             collection ? collection->getTypeName() : "[undetermined]"),
                 thisClass->name(), StatusCode::FAILURE);
@@ -216,7 +215,7 @@ namespace details {
             std::get<Index>(inputTuple) = typedCollection;
           } else {
             throw GaudiException(
-                fmt::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
+                std::format("Failed to cast collection {} to the required type {}, the type of the collection is {}",
                             std::get<Index>(handles)[0].objKey(), typeid(EDM4hepType).name(),
                             collection ? collection->getTypeName() : "[undetermined]"),
                 thisClass->name(), StatusCode::FAILURE);
@@ -236,7 +235,7 @@ namespace details {
             // This is how the Marlin wrapper saves collections when converting from LCIO to EDM4hep
             const auto* marlinWrapper = dynamic_cast<const DataWrapper<podio::CollectionBase>*>(dataObject);
             if (!wrapper && !marlinWrapper) {
-              throw GaudiException(fmt::format("Failed to cast collection {} to the required type {}",
+              throw GaudiException(std::format("Failed to cast collection {} to the required type {}",
                                                std::get<Index>(handles)[0].objKey(), typeid(EDM4hepType).name()),
                                    thisClass->name(), StatusCode::FAILURE);
             }
@@ -264,7 +263,7 @@ namespace details {
       if constexpr (isVectorLike_v<std::tuple_element_t<Index, std::tuple<Out...>>>) {
         const auto& outputVector = std::get<Index>(outputs);
         if (outputHandles.size() != outputVector.size()) {
-          throw GaudiException(fmt::format("Size of the output vector {} with type {} does not match the expected size "
+          throw GaudiException(std::format("Size of the output vector {} with type {} does not match the expected size "
                                            "from the steering file {}",
                                            outputHandles.size(), typeid(outputHandles).name(), outputVector.size()),
                                thisClass->name(), StatusCode::FAILURE);
@@ -323,7 +322,7 @@ namespace details {
   const T& FunctionalDataObjectReadHandle<T>::get() const {
     const auto dataObj = this->fetch();
     if (!dataObj) {
-      throw GaudiException(fmt::format("Cannot retrieve '{}' from transient store [{}]", this->objKey(),
+      throw GaudiException(std::format("Cannot retrieve '{}' from transient store [{}]", this->objKey(),
                                        this->m_owner ? this->owner()->name() : "no owner"),
                            "FunctionalDataObjectReadHandle", StatusCode::FAILURE);
     }

--- a/k4FWCore/src/KeepDropSwitch.cpp
+++ b/k4FWCore/src/KeepDropSwitch.cpp
@@ -22,10 +22,8 @@
 #include <stdexcept>
 #ifdef __cpp_lib_format
 #include <format>
-using std::format;
 #else
 #include <fmt/format.h>
-using fmt::format;
 #endif
 
 namespace {
@@ -78,7 +76,11 @@ KeepDropSwitch::KeepDropSwitch(const InputCommands& cmds) {
   for (const auto& cmdLine : cmds) {
     auto [cmd, kind, arg] = extractCommand(cmdLine);
     if (cmd == Cmd::INVALID) {
-      throw std::invalid_argument(format("'{}' is not a valid command for the KeepDropSwitch", cmdLine));
+#ifdef __cpp_lib_format
+      throw std::invalid_argument(std::format("'{}' is not a valid command for the KeepDropSwitch", cmdLine));
+#else
+      throw std::invalid_argument(fmt::format("'{}' is not a valid command for the KeepDropSwitch", cmdLine));
+#endif
     }
     m_outputCommands.emplace_back(cmd, kind, std::move(arg));
   }

--- a/k4FWCore/src/KeepDropSwitch.cpp
+++ b/k4FWCore/src/KeepDropSwitch.cpp
@@ -18,9 +18,9 @@
  */
 #include "k4FWCore/KeepDropSwitch.h"
 
+#include <format>
 #include <sstream>
 #include <stdexcept>
-#include <format>
 
 namespace {
 int wildcmp(const char* wild, const char* string) noexcept {

--- a/k4FWCore/src/KeepDropSwitch.cpp
+++ b/k4FWCore/src/KeepDropSwitch.cpp
@@ -20,11 +20,7 @@
 
 #include <sstream>
 #include <stdexcept>
-#ifdef __cpp_lib_format
 #include <format>
-#else
-#include <fmt/format.h>
-#endif
 
 namespace {
 int wildcmp(const char* wild, const char* string) noexcept {
@@ -76,11 +72,7 @@ KeepDropSwitch::KeepDropSwitch(const InputCommands& cmds) {
   for (const auto& cmdLine : cmds) {
     auto [cmd, kind, arg] = extractCommand(cmdLine);
     if (cmd == Cmd::INVALID) {
-#ifdef __cpp_lib_format
       throw std::invalid_argument(std::format("'{}' is not a valid command for the KeepDropSwitch", cmdLine));
-#else
-      throw std::invalid_argument(fmt::format("'{}' is not a valid command for the KeepDropSwitch", cmdLine));
-#endif
     }
     m_outputCommands.emplace_back(cmd, kind, std::move(arg));
   }

--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -24,7 +24,6 @@
 
 #include <Gaudi/Property.h>
 
-
 #include <atomic>
 #include <format>
 #include <stdexcept>

--- a/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleEventHeaderConsumer.cpp
@@ -24,9 +24,9 @@
 
 #include <Gaudi/Property.h>
 
-#include <fmt/core.h>
 
 #include <atomic>
+#include <format>
 #include <stdexcept>
 #include <string>
 
@@ -44,13 +44,13 @@ struct ExampleEventHeaderConsumer final : k4FWCore::Consumer<void(const edm4hep:
     }
 
     if (evtHeader.getRunNumber() != m_runNumber) {
-      throw std::runtime_error(fmt::format("Run number is not set correctly (expected {}, actual {})",
+      throw std::runtime_error(std::format("Run number is not set correctly (expected {}, actual {})",
                                            m_runNumber.value(), evtHeader.getRunNumber()));
     }
 
     const auto expectedEvent = m_evtCounter++ + m_eventNumberOffset;
     if (evtHeader.getEventNumber() != expectedEvent) {
-      throw std::runtime_error(fmt::format("Event number is not set correctly (expected {}, actual {})", expectedEvent,
+      throw std::runtime_error(std::format("Event number is not set correctly (expected {}, actual {})", expectedEvent,
                                            evtHeader.getEventNumber()));
     }
   }

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultipleKeyValues.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalConsumerMultipleKeyValues.cpp
@@ -42,12 +42,12 @@ using TrackColl = edm4hep::TrackCollection;
 using RecoColl = edm4hep::ReconstructedParticleCollection;
 using LinkColl = edm4hep::RecoMCParticleLinkCollection;
 
-struct ExampleFunctionalConsumerMultiple final
+struct ExampleFunctionalConsumerMultipleKeyValues final
     : k4FWCore::Consumer<void(const FloatColl&, const ParticleColl&, const SimTrackerHitColl&, const TrackerHitColl&,
                               const TrackColl&, const RecoColl&, const LinkColl&)> {
   // The pairs in KeyValue can be changed from python and they correspond
   // to the names of the input collections
-  ExampleFunctionalConsumerMultiple(const std::string& name, ISvcLocator* svcLoc)
+  ExampleFunctionalConsumerMultipleKeyValues(const std::string& name, ISvcLocator* svcLoc)
       : Consumer(name, svcLoc,
                  {
                      KeyValues("InputCollectionFloat", {"VectorFloat"}),
@@ -129,4 +129,4 @@ private:
   Gaudi::Property<int> m_offset{this, "Offset", 10, "Integer to add to the dummy values written to the edm"};
 };
 
-DECLARE_COMPONENT(ExampleFunctionalConsumerMultiple)
+DECLARE_COMPONENT(ExampleFunctionalConsumerMultipleKeyValues)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalTransformerRuntimeCollectionsMultiple.cpp
@@ -32,24 +32,26 @@
 #include <stdexcept>
 #include <string>
 
-// Which type of collection we are reading
-using FloatColl = std::vector<const podio::UserDataCollection<float>*>;
-using ParticleColl = std::vector<const edm4hep::MCParticleCollection*>;
-using SimTrackerHitColl = std::vector<const edm4hep::SimTrackerHitCollection*>;
-using TrackerHitColl = std::vector<const edm4hep::TrackerHit3DCollection*>;
-using TrackColl = std::vector<const edm4hep::TrackCollection*>;
-using RecoColl = std::vector<const edm4hep::ReconstructedParticleCollection*>;
-using LinkColl = std::vector<const edm4hep::RecoMCParticleLinkCollection*>;
+// Which type of collection we are reading (vectors of pointers for runtime collections)
+using FloatCollVec = std::vector<const podio::UserDataCollection<float>*>;
+using ParticleCollVec = std::vector<const edm4hep::MCParticleCollection*>;
+using SimTrackerHitCollVec = std::vector<const edm4hep::SimTrackerHitCollection*>;
+using TrackerHitCollVec = std::vector<const edm4hep::TrackerHit3DCollection*>;
+using TrackCollVec = std::vector<const edm4hep::TrackCollection*>;
+using RecoCollVec = std::vector<const edm4hep::ReconstructedParticleCollection*>;
+using LinkCollVec = std::vector<const edm4hep::RecoMCParticleLinkCollection*>;
 
-using retType = std::tuple<std::vector<podio::UserDataCollection<float>>, std::vector<edm4hep::MCParticleCollection>,
-                           std::vector<edm4hep::MCParticleCollection>, std::vector<edm4hep::SimTrackerHitCollection>,
-                           std::vector<edm4hep::TrackerHit3DCollection>, std::vector<edm4hep::TrackCollection>,
-                           std::vector<edm4hep::ReconstructedParticleCollection>,
-                           std::vector<edm4hep::RecoMCParticleLinkCollection>>;
+using RuntimeMultipleRetType =
+    std::tuple<std::vector<podio::UserDataCollection<float>>, std::vector<edm4hep::MCParticleCollection>,
+               std::vector<edm4hep::MCParticleCollection>, std::vector<edm4hep::SimTrackerHitCollection>,
+               std::vector<edm4hep::TrackerHit3DCollection>, std::vector<edm4hep::TrackCollection>,
+               std::vector<edm4hep::ReconstructedParticleCollection>,
+               std::vector<edm4hep::RecoMCParticleLinkCollection>>;
 
 struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
-    : k4FWCore::MultiTransformer<retType(const FloatColl&, const ParticleColl&, const SimTrackerHitColl&,
-                                         const TrackerHitColl&, const TrackColl&, const RecoColl&, const LinkColl&)> {
+    : k4FWCore::MultiTransformer<RuntimeMultipleRetType(const FloatCollVec&, const ParticleCollVec&,
+                                                        const SimTrackerHitCollVec&, const TrackerHitCollVec&,
+                                                        const TrackCollVec&, const RecoCollVec&, const LinkCollVec&)> {
   // The pairs in KeyValue can be changed from python and they correspond
   // to the names of the input collections
   ExampleFunctionalTransformerRuntimeCollectionsMultiple(const std::string& name, ISvcLocator* svcLoc)
@@ -77,9 +79,10 @@ struct ExampleFunctionalTransformerRuntimeCollectionsMultiple final
   // This is the function that will be called to transform the data
   // Note that the function has to be const, as well as the collections
   // we get from the input
-  retType operator()(const FloatColl& floatVec, const ParticleColl& particlesVec,
-                     const SimTrackerHitColl& simTrackerHitVec, const TrackerHitColl& trackerHitVec,
-                     const TrackColl& trackVec, const RecoColl& recoVec, const LinkColl& linkVec) const override {
+  RuntimeMultipleRetType operator()(const FloatCollVec& floatVec, const ParticleCollVec& particlesVec,
+                                    const SimTrackerHitCollVec& simTrackerHitVec,
+                                    const TrackerHitCollVec& trackerHitVec, const TrackCollVec& trackVec,
+                                    const RecoCollVec& recoVec, const LinkCollVec& linkVec) const override {
     auto floatVecOut = std::vector<podio::UserDataCollection<float>>();
     auto particleVecOut = std::vector<edm4hep::MCParticleCollection>();
     auto particle2VecOut = std::vector<edm4hep::MCParticleCollection>();


### PR DESCRIPTION
This PR adds support for CMAKE_UNITY_BUILD (see https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html), which reduces compilation time significantly. Note that podio (and EDM4hep by extension) already has it (https://github.com/AIDASoft/podio/pull/746).
This is now supported in Gaudi (see https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1887).

BEGINRELEASENOTES
- Changes to make `CMAKE_UNITY_BUILD` work:
  - Rename a few aliases so they don't collide when combining `.cpp` files
  - Use `std::format` instead of `fmt::format` when possible (not always necessary for Unity builds to work)
  - Fix the name of an algorithm that was copied and pasted and kept the old name (now colliding)

ENDRELEASENOTES