### PR TITLE
Add properties related to existing parameters to the MetadataSvc

### DIFF
--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -19,6 +19,7 @@
 #ifndef FWCORE_METADATASVC_H
 #define FWCORE_METADATASVC_H
 
+#include "Gaudi/Property.h"
 #include "GaudiKernel/IDataProviderSvc.h"
 #include "GaudiKernel/Service.h"
 
@@ -35,6 +36,9 @@ public:
   StatusCode initialize() override;
   StatusCode finalize() override;
 
+  bool throwIfDuplicate() const override { return m_throwIfDuplicate; }
+  bool skipIfSameValue() const override { return m_skipIfSameValue; }
+
 protected:
   SmartIF<IDataProviderSvc> m_dataSvc;
 
@@ -44,6 +48,13 @@ protected:
   podio::Frame* getFrame() override;
   void setFrame(podio::Frame frame) override;
   void throwIfRunning() const override;
+
+private:
+  Gaudi::Property<bool> m_throwIfDuplicate{this, "ThrowIfDuplicate", true,
+                                           "Throw an exception if a metadata parameter is already set"};
+  Gaudi::Property<bool> m_skipIfSameValue{
+      this, "SkipIfSameValue", true,
+      "Silently skip putting a metadata parameter if the existing value is the same as the new value"};
 };
 
 #endif

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -53,7 +53,7 @@ private:
   Gaudi::Property<bool> m_throwIfDuplicate{this, "ThrowIfDuplicate", true,
                                            "Throw an exception if a metadata parameter is already set"};
   Gaudi::Property<bool> m_skipIfSameValue{
-      this, "SkipIfSameValue", true,
+      this, "SkipIfSameValue", false,
       "Silently skip putting a metadata parameter if the existing value is the same as the new value"};
 };
 

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -33,6 +33,9 @@ public:
 
   virtual void setFrame(podio::Frame frame) = 0;
 
+  virtual bool throwIfDuplicate() const = 0;
+  virtual bool skipIfSameValue() const = 0;
+
   template <typename T>
   void put(const std::string& name, const T& obj) {
     getFrameForWrite()->putParameter(name, obj);

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -57,6 +57,9 @@ void putParameter(const std::string& name, const T& value, const GaudiComp* comp
     comp->error() << "MetadataSvc not found" << endmsg;
     return;
   }
+  if (metadataSvc->template get<T>(name).has_value()) {
+    comp->warning() << "Metadata parameter '" << name << "' is already set and will be overwritten" << endmsg;
+  }
   metadataSvc->template put<T>(name, value);
 }
 

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -28,6 +28,8 @@
 
 #include <edm4hep/Constants.h>
 
+#include <GaudiKernel/GaudiException.h>
+
 #include <optional>
 #include <ostream>
 
@@ -57,7 +59,14 @@ void putParameter(const std::string& name, const T& value, const GaudiComp* comp
     comp->error() << "MetadataSvc not found" << endmsg;
     return;
   }
-  if (metadataSvc->template get<T>(name).has_value()) {
+  const auto existing = metadataSvc->template get<T>(name);
+  if (existing.has_value()) {
+    if (metadataSvc->skipIfSameValue() && *existing == value) {
+      return;
+    }
+    if (metadataSvc->throwIfDuplicate()) {
+      throw GaudiException("Metadata parameter '" + name + "' is already set", comp->name(), StatusCode::FAILURE);
+    }
     comp->warning() << "Metadata parameter '" << name << "' is already set and will be overwritten" << endmsg;
   }
   metadataSvc->template put<T>(name, value);

--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -30,6 +30,7 @@
 
 #include <GaudiKernel/GaudiException.h>
 
+#include <concepts>
 #include <optional>
 #include <ostream>
 
@@ -47,7 +48,7 @@ concept Streamable = requires(std::ostream& os, const T& v) {
 ///             parameter, typically "this"
 /// @tparam GaudiComp The type of the component. This will be deduced in
 ///                   pretty much all of the use cases
-template <typename T, typename GaudiComp>
+template <std::equality_comparable T, typename GaudiComp>
 void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
   comp->debug() << "Trying to put parameter '" << name << "'";
   if constexpr (Streamable<T>) {

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -217,7 +217,8 @@ add_test_fwcore(FunctionalTransformerRuntimeCollectionsMultiple options/ExampleF
 add_test_fwcore(FunctionalTransformerHist options/ExampleFunctionalTransformerHist.py ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalCollectionMerger options/ExampleFunctionalCollectionMerger.py PROPERTIES FIXTURES_REQUIRED ProducerMultipleFile ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalFilterFile options/ExampleFunctionalFilterFile.py ADD_TO_CHECK_FILES)
-add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile)
+add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile
+                  PASS_REGULAR_EXPRESSION "Metadata parameter '.*' is already set and will be overwritten")
 add_test_fwcore(FunctionalMetadataRead options/ExampleFunctionalMetadataRead.py PROPERTIES FIXTURES_REQUIRED FunctionalMetadataFile ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalMetadataEventLoop options/ExampleFunctionalMetadataEventLoop.py
                   PROPERTIES PASS_REGULAR_EXPRESSION "putParameter cannot be called during the event loop")

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -217,8 +217,10 @@ add_test_fwcore(FunctionalTransformerRuntimeCollectionsMultiple options/ExampleF
 add_test_fwcore(FunctionalTransformerHist options/ExampleFunctionalTransformerHist.py ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalCollectionMerger options/ExampleFunctionalCollectionMerger.py PROPERTIES FIXTURES_REQUIRED ProducerMultipleFile ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalFilterFile options/ExampleFunctionalFilterFile.py ADD_TO_CHECK_FILES)
-add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile
-                  PASS_REGULAR_EXPRESSION "Metadata parameter '.*' is already set and will be overwritten")
+add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile)
+add_test_fwcore(FunctionalMetadataThrow options/ExampleFunctionalMetadata.py --Producer2.ParticleTime 2.5
+                  --IOSvc.Output functional_metadata_throw.root
+                  PROPERTIES PASS_REGULAR_EXPRESSION "Metadata parameter '.*' is already set")
 add_test_fwcore(FunctionalMetadataRead options/ExampleFunctionalMetadataRead.py PROPERTIES FIXTURES_REQUIRED FunctionalMetadataFile ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalMetadataEventLoop options/ExampleFunctionalMetadataEventLoop.py
                   PROPERTIES PASS_REGULAR_EXPRESSION "putParameter cannot be called during the event loop")

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -217,7 +217,7 @@ add_test_fwcore(FunctionalTransformerRuntimeCollectionsMultiple options/ExampleF
 add_test_fwcore(FunctionalTransformerHist options/ExampleFunctionalTransformerHist.py ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalCollectionMerger options/ExampleFunctionalCollectionMerger.py PROPERTIES FIXTURES_REQUIRED ProducerMultipleFile ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalFilterFile options/ExampleFunctionalFilterFile.py ADD_TO_CHECK_FILES)
-add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile)
+add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py --MetadataSvc.SkipIfSameValue True ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile)
 add_test_fwcore(FunctionalMetadataThrow options/ExampleFunctionalMetadata.py --Producer2.ParticleTime 2.5
                   --IOSvc.Output functional_metadata_throw.root
                   PROPERTIES PASS_REGULAR_EXPRESSION "Metadata parameter '.*' is already set")

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
@@ -42,10 +42,15 @@ producer = ExampleFunctionalMetadataProducer(
     vectorStringProp2=["one", "two", "three", "four"],
     OutputCollection=["MCParticles"],
 )
+# Second producer using the same metadata parameter names to trigger overwrite warnings
+producer2 = ExampleFunctionalMetadataProducer(
+    "Producer2",
+    OutputCollection=["MCParticles2"],
+)
 consumer = ExampleFunctionalMetadataConsumer("Consumer", InputCollection=["MCParticles"])
 
 ApplicationMgr(
-    TopAlg=[producer, consumer],
+    TopAlg=[producer, producer2, consumer],
     EvtSel="NONE",
     EvtMax=10,
     ExtSvc=[EventDataSvc("EventDataSvc")],

--- a/test/k4FWCoreTest/options/ExampleTool.py
+++ b/test/k4FWCoreTest/options/ExampleTool.py
@@ -20,10 +20,12 @@
 from Gaudi.Configuration import INFO
 from Configurables import ExampleToolFunctional, ExampleToolA
 from k4FWCore import ApplicationMgr, IOSvc
-from Configurables import EventDataSvc
+from Configurables import EventDataSvc, MetadataSvc
 
 iosvc = IOSvc()
 iosvc.Output = "example_tool.root"
+metadatasvc = MetadataSvc("MetadataSvc")
+metadatasvc.ThrowIfDuplicate = False
 
 user = ExampleToolFunctional("ToolUser")
 

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -223,7 +223,7 @@ for i in range(len(merged_links)):
         )
 
 
-check_collections("functional_metadata.root", ["MCParticles"])
+check_collections("functional_metadata.root", ["MCParticles", "MCParticles2"])
 
 check_metadata(
     "functional_metadata.root",


### PR DESCRIPTION
BEGINRELEASENOTES
- Add two properties, `ThrowIfDuplicate` and `SkipIfSameValue`. This will change the behaviour of existing code since now it will throw if there is a duplicate by default (although there are not many cases where the MetadataSvc is being used).

ENDRELEASENOTES

See https://github.com/key4hep/k4FWCore/issues/301. There is no data race because the read and write operations are locked with the same mutex in podio.

Close https://github.com/key4hep/k4FWCore/issues/301.