### PR TITLE
Disallow setting metadata parameters in the event loop

### DIFF
--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -22,8 +22,10 @@
 #include "podio/Frame.h"
 
 #include <GaudiKernel/AnyDataWrapper.h>
+#include <GaudiKernel/GaudiException.h>
 #include <GaudiKernel/IDataProviderSvc.h>
 #include <GaudiKernel/Service.h>
+#include <GaudiKernel/StateMachine.h>
 
 #include <memory>
 
@@ -42,6 +44,12 @@ StatusCode MetadataSvc::initialize() {
 }
 
 StatusCode MetadataSvc::finalize() { return Service::finalize(); }
+
+void MetadataSvc::throwIfRunning() const {
+  if (targetFSMState() == Gaudi::StateMachine::RUNNING) {
+    throw GaudiException("putParameter cannot be called during the event loop", name(), StatusCode::FAILURE);
+  }
+}
 
 const podio::Frame* MetadataSvc::getFrame() const { return m_frame.get(); }
 podio::Frame* MetadataSvc::getFrame() { return m_frame.get(); }

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -43,6 +43,7 @@ protected:
   const podio::Frame* getFrame() const override;
   podio::Frame* getFrame() override;
   void setFrame(podio::Frame frame) override;
+  void throwIfRunning() const override;
 };
 
 #endif

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -35,6 +35,7 @@ public:
 
   template <typename T>
   void put(const std::string& name, const T& obj) {
+    throwIfRunning();
     getFrameForWrite()->putParameter(name, obj);
   }
 
@@ -50,6 +51,7 @@ public:
 protected:
   virtual podio::Frame* getFrame() = 0;
   virtual const podio::Frame* getFrame() const = 0;
+  virtual void throwIfRunning() const {}
 
 private:
   podio::Frame* getFrameForWrite() {
@@ -63,6 +65,7 @@ private:
 template <>
 inline void IMetadataSvc::put<edm4hep::utils::ParticleIDMeta>(const std::string& collName,
                                                               const edm4hep::utils::ParticleIDMeta& pidMetaInfo) {
+  throwIfRunning();
   edm4hep::utils::PIDHandler::setAlgoInfo(*getFrameForWrite(), collName, pidMetaInfo);
 }
 

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -35,7 +35,6 @@ public:
 
   template <typename T>
   void put(const std::string& name, const T& obj) {
-    throwIfRunning();
     getFrameForWrite()->putParameter(name, obj);
   }
 
@@ -55,6 +54,7 @@ protected:
 
 private:
   podio::Frame* getFrameForWrite() {
+    throwIfRunning();
     if (!getFrame()) {
       setFrame(podio::Frame());
     }
@@ -65,7 +65,6 @@ private:
 template <>
 inline void IMetadataSvc::put<edm4hep::utils::ParticleIDMeta>(const std::string& collName,
                                                               const edm4hep::utils::ParticleIDMeta& pidMetaInfo) {
-  throwIfRunning();
   edm4hep::utils::PIDHandler::setAlgoInfo(*getFrameForWrite(), collName, pidMetaInfo);
 }
 

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -218,6 +218,8 @@ add_test_fwcore(FunctionalCollectionMerger options/ExampleFunctionalCollectionMe
 add_test_fwcore(FunctionalFilterFile options/ExampleFunctionalFilterFile.py ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalMetadata options/ExampleFunctionalMetadata.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP FunctionalMetadataFile)
 add_test_fwcore(FunctionalMetadataRead options/ExampleFunctionalMetadataRead.py PROPERTIES FIXTURES_REQUIRED FunctionalMetadataFile ADD_TO_CHECK_FILES)
+add_test_fwcore(FunctionalMetadataEventLoop options/ExampleFunctionalMetadataEventLoop.py
+                  PROPERTIES PASS_REGULAR_EXPRESSION "putParameter cannot be called during the event loop")
 add_test_fwcore(FunctionalMetadataOldAlgorithm options/ExampleFunctionalMetadataOldAlgorithm.py ADD_TO_CHECK_FILES PROPERTIES FIXTURES_SETUP OldAlgorithmFile)
 add_test_fwcore(createEventHeaderConcurrent options/createEventHeaderConcurrent.py ADD_TO_CHECK_FILES)
 add_test_fwcore(FunctionalMetadataReadOldAlgorithm options/ExampleFunctionalMetadataReadOldAlgorithm.py PROPERTIES FIXTURES_REQUIRED OldAlgorithmFile ADD_TO_CHECK_FILES)

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadataEventLoop.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadataEventLoop.py
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This test verifies that calling putParameter during the event loop raises an error
+
+from Gaudi.Configuration import INFO
+from Configurables import ExampleFunctionalMetadataProducer
+from k4FWCore import ApplicationMgr
+from Configurables import EventDataSvc, MetadataSvc
+
+producer = ExampleFunctionalMetadataProducer(
+    "Producer",
+    OutputCollection=["MCParticles"],
+    PutMetadataInEventLoop=True,
+)
+
+ApplicationMgr(
+    TopAlg=[producer],
+    EvtSel="NONE",
+    EvtMax=3,
+    ExtSvc=[EventDataSvc("EventDataSvc"), MetadataSvc("MetadataSvc")],
+    OutputLevel=INFO,
+)

--- a/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
+++ b/test/k4FWCoreTest/src/components/ExampleFunctionalMetadataProducer.cpp
@@ -42,8 +42,9 @@ struct ExampleFunctionalMetadataProducer final : k4FWCore::Producer<edm4hep::MCP
   }
 
   edm4hep::MCParticleCollection operator()() const override {
-    // Putting metadata in the main loop doesn't work
-    // k4FWCore::putParameter("EventMetadataInt", 5, this);
+    if (m_putMetadataInEventLoop) {
+      k4FWCore::putParameter("EventMetadataInt", 5, this);
+    }
     auto coll = edm4hep::MCParticleCollection();
     for (int i = 0; i < m_particleNum.value(); ++i) {
       auto particle = coll.create();
@@ -66,6 +67,8 @@ private:
       this, "PDGValues", {1, 2, 3, 4}, "Values of the PDG used for the particles"};
 
   // Some properties for the configuration metadata
+  Gaudi::Property<bool> m_putMetadataInEventLoop{this, "PutMetadataInEventLoop", false,
+                                                 "If true, attempt to put metadata during the event loop (will throw)"};
   Gaudi::Property<int> m_intProp{this, "intProp", 42, "An integer property"};
   Gaudi::Property<int> m_intProp2{this, "intProp2", 42, "An integer property"};
   Gaudi::Property<float> m_floatProp{this, "floatProp", 3.14, "A float property"};


### PR DESCRIPTION
Fix https://github.com/key4hep/k4FWCore/issues/302

BEGINRELEASENOTES
- Disallow setting metadata parameters in the event loop
- Add a test that checks that it is not possible

ENDRELEASENOTES

Create a function since this check is also needed in the `put` override for edm4hep::utils::ParticleIDMeta.