### PR TITLE
Remove the deprecated -v and --verbose args for k4run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ positional arguments:
 
 options:
   --dry-run             Do not actually run the job, just parse the config files
-  -v, --verbose         Run job with verbose output
   -n NUM_EVENTS, --num-events NUM_EVENTS
                         Number of events to run
   -l, --list            Print all the configurable components available in the framework and exit

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -121,18 +121,6 @@ def add_arguments(parser, app_mgr):
     return option_db
 
 
-class DeprecatedStoreTrueAction(argparse.Action):
-    def __init__(self, option_strings, dest, nargs=0, **kwargs):
-        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        warnings.warn(
-            f"Argument '{self.dest}' is deprecated and will be removed in a future version.",
-            DeprecationWarning,
-        )
-        setattr(namespace, self.dest, True)
-
-
 def startInteractive(vars):
     """Start an interactive session"""
     import code
@@ -170,12 +158,6 @@ def main():
         "--dry-run",
         action="store_true",
         help="Do not actually run the job, just parse the config files",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action=DeprecatedStoreTrueAction,
-        help="[deprecated: use --log-level=verbose] Run job with verbose output",
     )
     parser.add_argument("-n", "--num-events", type=int, help="Number of events to run")
     parser.add_argument(

--- a/k4FWCore/scripts/k4run
+++ b/k4FWCore/scripts/k4run
@@ -193,8 +193,6 @@ def main():
     # in the namespace since parsing of the file happens when the namespace
     # has already been filled
     opts = parser.parse_known_args()
-    if opts[0].verbose:
-        opts[0].log_level = "VERBOSE"
     logger = get_logger()
     set_log_level(opts[0].log_level or "INFO")
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Remove the deprecated -v and --verbose args for k4run

ENDRELEASENOTES

It has been deprecated for ~1 year.

Check the downstream build to see if there are failures.