### PR TITLE
Allow pre-filling parameters for the MetadataSvc

### DIFF
--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -40,8 +40,8 @@ StatusCode MetadataSvc::initialize() {
     error() << "Unable to locate the EventDataSvc" << endmsg;
     return StatusCode::FAILURE;
   }
-  bool hasParameters = !m_intParameters.empty() || !m_floatParameters.empty() ||
-                       !m_doubleParameters.empty() || !m_stringParameters.value().empty();
+  bool hasParameters = !m_intParameters.empty() || !m_floatParameters.empty() || !m_doubleParameters.empty() ||
+                       !m_stringParameters.value().empty();
   if (hasParameters && !m_setAtFinalize) {
     // If there is a reader, then the metadata frame will be set from the IOSvc
     // to what is read from the Reader

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -87,7 +87,7 @@ void MetadataSvc::applyPropertyParameters() {
     m_frame->putParameter(key, val);
   }
   for (const auto& [key, val] : m_floatParameters) {
-    m_frame->putParameter(key, val);
+    m_frame->putParameter<float>(key, static_cast<float>(val));
   }
   for (const auto& [key, val] : m_doubleParameters) {
     m_frame->putParameter(key, val);

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -40,6 +40,16 @@ StatusCode MetadataSvc::initialize() {
     error() << "Unable to locate the EventDataSvc" << endmsg;
     return StatusCode::FAILURE;
   }
+  bool hasParameters = !m_intParameters.empty() || !m_floatParameters.empty() ||
+                       !m_doubleParameters.empty() || !m_stringParameters.value().empty();
+  if (hasParameters && !m_setAtFinalize) {
+    // If there is a reader, then the metadata frame will be set from the IOSvc
+    // to what is read from the Reader
+    if (!m_frame) {
+      m_frame = std::make_unique<podio::Frame>();
+    }
+    applyPropertyParameters();
+  }
   return StatusCode::SUCCESS;
 }
 
@@ -52,7 +62,39 @@ void MetadataSvc::throwIfRunning() const {
 }
 
 const podio::Frame* MetadataSvc::getFrame() const { return m_frame.get(); }
-podio::Frame* MetadataSvc::getFrame() { return m_frame.get(); }
-void MetadataSvc::setFrame(podio::Frame frame) { m_frame = std::make_unique<podio::Frame>(std::move(frame)); }
+
+podio::Frame* MetadataSvc::getFrame() {
+  if (m_setAtFinalize && !m_paramsApplied) {
+    if (!m_frame) {
+      m_frame = std::make_unique<podio::Frame>();
+    }
+    applyPropertyParameters();
+    m_paramsApplied = true;
+  }
+  return m_frame.get();
+}
+
+void MetadataSvc::setFrame(podio::Frame frame) {
+  m_frame = std::make_unique<podio::Frame>(std::move(frame));
+  m_paramsApplied = false;
+  if (!m_setAtFinalize) {
+    applyPropertyParameters();
+  }
+}
+
+void MetadataSvc::applyPropertyParameters() {
+  for (const auto& [key, val] : m_intParameters) {
+    m_frame->putParameter(key, val);
+  }
+  for (const auto& [key, val] : m_floatParameters) {
+    m_frame->putParameter<float>(key, static_cast<float>(val));
+  }
+  for (const auto& [key, val] : m_doubleParameters) {
+    m_frame->putParameter(key, val);
+  }
+  for (const auto& [key, val] : m_stringParameters) {
+    m_frame->putParameter(key, val);
+  }
+}
 
 DECLARE_COMPONENT(MetadataSvc)

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -87,7 +87,7 @@ void MetadataSvc::applyPropertyParameters() {
     m_frame->putParameter(key, val);
   }
   for (const auto& [key, val] : m_floatParameters) {
-    m_frame->putParameter<float>(key, static_cast<float>(val));
+    m_frame->putParameter(key, val);
   }
   for (const auto& [key, val] : m_doubleParameters) {
     m_frame->putParameter(key, val);

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -55,6 +55,15 @@ StatusCode MetadataSvc::initialize() {
 
 StatusCode MetadataSvc::finalize() { return Service::finalize(); }
 
+void MetadataSvc::applyDeferredParameters() {
+  if (m_setAtFinalize && !m_paramsApplied) {
+    if (!m_frame) {
+      m_frame = std::make_unique<podio::Frame>();
+    }
+    applyPropertyParameters();
+  }
+}
+
 void MetadataSvc::throwIfRunning() const {
   if (targetFSMState() == Gaudi::StateMachine::RUNNING) {
     throw GaudiException("putParameter cannot be called during the event loop", name(), StatusCode::FAILURE);
@@ -63,15 +72,7 @@ void MetadataSvc::throwIfRunning() const {
 
 const podio::Frame* MetadataSvc::getFrame() const { return m_frame.get(); }
 
-podio::Frame* MetadataSvc::getFrame() {
-  if (m_setAtFinalize && !m_paramsApplied) {
-    if (!m_frame) {
-      m_frame = std::make_unique<podio::Frame>();
-    }
-    applyPropertyParameters();
-  }
-  return m_frame.get();
-}
+podio::Frame* MetadataSvc::getFrame() { return m_frame.get(); }
 
 void MetadataSvc::setFrame(podio::Frame frame) {
   m_frame = std::make_unique<podio::Frame>(std::move(frame));

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -41,7 +41,7 @@ StatusCode MetadataSvc::initialize() {
     return StatusCode::FAILURE;
   }
   bool hasParameters = !m_intParameters.empty() || !m_floatParameters.empty() || !m_doubleParameters.empty() ||
-                       !m_stringParameters.value().empty();
+                       !m_stringParameters.empty();
   if (hasParameters && !m_setAtFinalize) {
     // If there is a reader, then the metadata frame will be set from the IOSvc
     // to what is read from the Reader

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -69,14 +69,12 @@ podio::Frame* MetadataSvc::getFrame() {
       m_frame = std::make_unique<podio::Frame>();
     }
     applyPropertyParameters();
-    m_paramsApplied = true;
   }
   return m_frame.get();
 }
 
 void MetadataSvc::setFrame(podio::Frame frame) {
   m_frame = std::make_unique<podio::Frame>(std::move(frame));
-  m_paramsApplied = false;
   if (!m_setAtFinalize) {
     applyPropertyParameters();
   }
@@ -95,6 +93,7 @@ void MetadataSvc::applyPropertyParameters() {
   for (const auto& [key, val] : m_stringParameters) {
     m_frame->putParameter(key, val);
   }
+  m_paramsApplied = true;
 }
 
 DECLARE_COMPONENT(MetadataSvc)

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -54,7 +54,7 @@ StatusCode MetadataSvc::initialize() {
 StatusCode MetadataSvc::finalize() { return Service::finalize(); }
 
 void MetadataSvc::applyDeferredParameters() {
-  if (m_setAtFinalize && !m_paramsApplied) {
+  if (m_setAtFinalize) {
     if (!m_frame) {
       m_frame = std::make_unique<podio::Frame>();
     }
@@ -92,7 +92,6 @@ void MetadataSvc::applyPropertyParameters() {
   for (const auto& [key, val] : m_stringParameters) {
     m_frame->putParameter(key, val);
   }
-  m_paramsApplied = true;
 }
 
 DECLARE_COMPONENT(MetadataSvc)

--- a/k4FWCore/components/MetadataSvc.cpp
+++ b/k4FWCore/components/MetadataSvc.cpp
@@ -40,9 +40,7 @@ StatusCode MetadataSvc::initialize() {
     error() << "Unable to locate the EventDataSvc" << endmsg;
     return StatusCode::FAILURE;
   }
-  bool hasParameters = !m_intParameters.empty() || !m_floatParameters.empty() || !m_doubleParameters.empty() ||
-                       !m_stringParameters.empty();
-  if (hasParameters && !m_setAtFinalize) {
+  if (!m_setAtFinalize) {
     // If there is a reader, then the metadata frame will be set from the IOSvc
     // to what is read from the Reader
     if (!m_frame) {

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -27,7 +27,9 @@
 
 #include "k4FWCore/IMetadataSvc.h"
 
+#include <map>
 #include <memory>
+#include <string>
 
 class MetadataSvc : public extends<Service, IMetadataSvc> {
   using extends::extends;
@@ -50,11 +52,27 @@ protected:
   void throwIfRunning() const override;
 
 private:
+  void applyPropertyParameters();
+
+  bool m_paramsApplied{false};
+
   Gaudi::Property<bool> m_throwIfDuplicate{this, "ThrowIfDuplicate", true,
                                            "Throw an exception if a metadata parameter is already set"};
   Gaudi::Property<bool> m_skipIfSameValue{
       this, "SkipIfSameValue", false,
       "Silently skip putting a metadata parameter if the existing value is the same as the new value"};
+  Gaudi::Property<bool> m_setAtFinalize{
+      this, "SetAtFinalize", false,
+      "When true, apply the Python-configured parameters at finalize time instead of at initialize time"};
+  Gaudi::Property<std::map<std::string, int>> m_intParameters{
+      this, "IntParameters", {}, "Metadata int parameters to be set directly from Python"};
+  // Stored as float in the frame; Gaudi has no parser for map<string,float> so the property uses double
+  Gaudi::Property<std::map<std::string, double>> m_floatParameters{
+      this, "FloatParameters", {}, "Metadata float parameters to be set directly from Python"};
+  Gaudi::Property<std::map<std::string, double>> m_doubleParameters{
+      this, "DoubleParameters", {}, "Metadata double parameters to be set directly from Python"};
+  Gaudi::Property<std::map<std::string, std::string>> m_stringParameters{
+      this, "StringParameters", {}, "Metadata string parameters to be set directly from Python"};
 };
 
 #endif

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -66,7 +66,8 @@ private:
       "When true, apply the Python-configured parameters at finalize time instead of at initialize time"};
   Gaudi::Property<std::map<std::string, int>> m_intParameters{
       this, "IntParameters", {}, "Metadata int parameters to be set directly from Python"};
-  Gaudi::Property<std::map<std::string, float>> m_floatParameters{
+  // Stored as float in the frame; Gaudi has no parser for map<string,float> so the property uses double
+  Gaudi::Property<std::map<std::string, double>> m_floatParameters{
       this, "FloatParameters", {}, "Metadata float parameters to be set directly from Python"};
   Gaudi::Property<std::map<std::string, double>> m_doubleParameters{
       this, "DoubleParameters", {}, "Metadata double parameters to be set directly from Python"};

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -66,8 +66,7 @@ private:
       "When true, apply the Python-configured parameters at finalize time instead of at initialize time"};
   Gaudi::Property<std::map<std::string, int>> m_intParameters{
       this, "IntParameters", {}, "Metadata int parameters to be set directly from Python"};
-  // Stored as float in the frame; Gaudi has no parser for map<string,float> so the property uses double
-  Gaudi::Property<std::map<std::string, double>> m_floatParameters{
+  Gaudi::Property<std::map<std::string, float>> m_floatParameters{
       this, "FloatParameters", {}, "Metadata float parameters to be set directly from Python"};
   Gaudi::Property<std::map<std::string, double>> m_doubleParameters{
       this, "DoubleParameters", {}, "Metadata double parameters to be set directly from Python"};

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -55,8 +55,6 @@ protected:
 private:
   void applyPropertyParameters();
 
-  bool m_paramsApplied{false};
-
   Gaudi::Property<bool> m_throwIfDuplicate{this, "ThrowIfDuplicate", true,
                                            "Throw an exception if a metadata parameter is already set"};
   Gaudi::Property<bool> m_skipIfSameValue{

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -67,6 +67,7 @@ private:
   Gaudi::Property<std::map<std::string, int>> m_intParameters{
       this, "IntParameters", {}, "Metadata int parameters to be set directly from Python"};
   // Stored as float in the frame; Gaudi has no parser for map<string,float> so the property uses double
+  // Compile work with fmt 12.1.0 and Gaudi master (instead of 40.2), with Clang 22 and GCC 15
   Gaudi::Property<std::map<std::string, double>> m_floatParameters{
       this, "FloatParameters", {}, "Metadata float parameters to be set directly from Python"};
   Gaudi::Property<std::map<std::string, double>> m_doubleParameters{

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -67,7 +67,6 @@ private:
   Gaudi::Property<std::map<std::string, int>> m_intParameters{
       this, "IntParameters", {}, "Metadata int parameters to be set directly from Python"};
   // Stored as float in the frame; Gaudi has no parser for map<string,float> so the property uses double
-  // Compile work with fmt 12.1.0 and Gaudi master (instead of 40.2), with Clang 22 and GCC 15
   Gaudi::Property<std::map<std::string, double>> m_floatParameters{
       this, "FloatParameters", {}, "Metadata float parameters to be set directly from Python"};
   Gaudi::Property<std::map<std::string, double>> m_doubleParameters{

--- a/k4FWCore/components/MetadataSvc.h
+++ b/k4FWCore/components/MetadataSvc.h
@@ -40,6 +40,7 @@ public:
 
   bool throwIfDuplicate() const override { return m_throwIfDuplicate; }
   bool skipIfSameValue() const override { return m_skipIfSameValue; }
+  void applyDeferredParameters() override;
 
 protected:
   SmartIF<IDataProviderSvc> m_dataSvc;

--- a/k4FWCore/components/Writer.cpp
+++ b/k4FWCore/components/Writer.cpp
@@ -112,6 +112,7 @@ public:
   }
 
   StatusCode finalize() override {
+    m_metadataSvc->applyDeferredParameters();
     if (const auto* metadata_frame = m_metadataSvc->getFrame(); metadata_frame) {
       iosvc->getWriter().writeFrame(*metadata_frame, podio::Category::Metadata);
     }

--- a/k4FWCore/include/k4FWCore/IMetadataSvc.h
+++ b/k4FWCore/include/k4FWCore/IMetadataSvc.h
@@ -36,6 +36,8 @@ public:
   virtual bool throwIfDuplicate() const = 0;
   virtual bool skipIfSameValue() const = 0;
 
+  virtual void applyDeferredParameters() {}
+
   template <typename T>
   void put(const std::string& name, const T& obj) {
     getFrameForWrite()->putParameter(name, obj);

--- a/python/k4FWCore/MetadataUtils.py
+++ b/python/k4FWCore/MetadataUtils.py
@@ -1,0 +1,59 @@
+#
+# Copyright (c) 2014-2024 Key4hep-Project.
+#
+# This file is part of Key4hep.
+# See https://key4hep.github.io/key4hep-doc/ for further info.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def putMetadata(parameters, default_float_type="double", set_at_finalize=False):
+    if default_float_type not in ("float", "double"):
+        raise ValueError(
+            f"default_float_type must be 'float' or 'double', got '{default_float_type}'"
+        )
+
+    from Configurables import MetadataSvc
+
+    svc = MetadataSvc("MetadataSvc")
+    int_params = dict(svc.IntParameters)
+    float_params = dict(svc.FloatParameters)
+    double_params = dict(svc.DoubleParameters)
+    str_params = dict(svc.StringParameters)
+
+    for key, value in parameters.items():
+        if isinstance(value, bool):
+            raise TypeError(
+                f"Metadata parameter '{key}' has type bool which is not supported; use int, float, or str"
+            )
+        elif isinstance(value, int):
+            int_params[key] = value
+        elif isinstance(value, float):
+            if default_float_type == "float":
+                float_params[key] = value
+            else:
+                double_params[key] = value
+        elif isinstance(value, str):
+            str_params[key] = value
+        else:
+            raise TypeError(
+                f"Metadata parameter '{key}' has unsupported type {type(value).__name__}; expected int, float, or str"
+            )
+
+    svc.IntParameters = int_params
+    svc.FloatParameters = float_params
+    svc.DoubleParameters = double_params
+    svc.StringParameters = str_params
+    if set_at_finalize:
+        svc.SetAtFinalize = True

--- a/python/k4FWCore/MetadataUtils.py
+++ b/python/k4FWCore/MetadataUtils.py
@@ -18,7 +18,7 @@
 #
 
 
-def putMetadata(parameters, default_float_type="double", set_at_finalize=False):
+def putMetadata(parameters, default_float_type="double"):
     if default_float_type not in ("float", "double"):
         raise ValueError(
             f"default_float_type must be 'float' or 'double', got '{default_float_type}'"
@@ -55,5 +55,3 @@ def putMetadata(parameters, default_float_type="double", set_at_finalize=False):
     svc.FloatParameters = float_params
     svc.DoubleParameters = double_params
     svc.StringParameters = str_params
-    if set_at_finalize:
-        svc.SetAtFinalize = True

--- a/python/k4FWCore/__init__.py
+++ b/python/k4FWCore/__init__.py
@@ -18,3 +18,4 @@
 #
 from .ApplicationMgr import ApplicationMgr
 from .IOSvc import IOSvc
+from .MetadataUtils import putMetadata, readMetadata

--- a/python/k4FWCore/__init__.py
+++ b/python/k4FWCore/__init__.py
@@ -18,4 +18,4 @@
 #
 from .ApplicationMgr import ApplicationMgr
 from .IOSvc import IOSvc
-from .MetadataUtils import putMetadata, readMetadata
+from .MetadataUtils import putMetadata

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
@@ -40,6 +40,8 @@ putMetadata(
 putMetadata({"PythonFloatParam": 3.0}, default_float_type="float")
 # Overwrite
 putMetadata({"PythonFloatParam": 4.0}, default_float_type="float")
+# This will make all parameters be set at finalize
+# Typically there won't be several calls of putMetadata
 putMetadata({"PythonFinalizeParam": 99}, set_at_finalize=True)
 
 producer = ExampleFunctionalMetadataProducer(

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
@@ -24,11 +24,23 @@ from Configurables import (
     ExampleFunctionalMetadataProducer,
     ExampleFunctionalMetadataConsumer,
 )
-from k4FWCore import ApplicationMgr, IOSvc
+from k4FWCore import ApplicationMgr, IOSvc, putMetadata
 from Configurables import EventDataSvc
 
 iosvc = IOSvc()
 iosvc.Output = "functional_metadata.root"
+
+putMetadata(
+    {
+        "PythonIntParam": 42,
+        "PythonDoubleParam": 3.14,
+        "PythonStringParam": "hello from python",
+    }
+)
+putMetadata({"PythonFloatParam": 3.0}, default_float_type="float")
+# Overwrite
+putMetadata({"PythonFloatParam": 4.0}, default_float_type="float")
+putMetadata({"PythonFinalizeParam": 99}, set_at_finalize=True)
 
 producer = ExampleFunctionalMetadataProducer(
     "Producer",

--- a/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalMetadata.py
@@ -23,6 +23,7 @@ from Gaudi.Configuration import INFO
 from Configurables import (
     ExampleFunctionalMetadataProducer,
     ExampleFunctionalMetadataConsumer,
+    MetadataSvc,
 )
 from k4FWCore import ApplicationMgr, IOSvc, putMetadata
 from Configurables import EventDataSvc
@@ -40,9 +41,8 @@ putMetadata(
 putMetadata({"PythonFloatParam": 3.0}, default_float_type="float")
 # Overwrite
 putMetadata({"PythonFloatParam": 4.0}, default_float_type="float")
-# This will make all parameters be set at finalize
-# Typically there won't be several calls of putMetadata
-putMetadata({"PythonFinalizeParam": 99}, set_at_finalize=True)
+MetadataSvc("MetadataSvc").SetAtFinalize = True
+putMetadata({"PythonFinalizeParam": 99})
 
 producer = ExampleFunctionalMetadataProducer(
     "Producer",

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -233,25 +233,15 @@ check_metadata(
         "PDGValues": [1, 2, 3, 4],
         "MetadataString": "hello",
         "FinalizeMetadataInt": 10,
+        "PythonIntParam": 42,
+        "PythonFloatParam": 4.0,
+        "PythonDoubleParam": 3.14,
+        "PythonStringParam": "hello from python",
+        "PythonFinalizeParam": 99,
     },
 )
 
-reader = podio.reading.get_reader("functional_metadata.root")
-metadata = reader.get("metadata")[0]
-for key, value in zip(
-    [
-        "NumberOfParticles",
-        "ParticleTime",
-        "PDGValues",
-        "MetadataString",
-        "FinalizeMetadataInt",
-    ],
-    [3, 1.5, [1, 2, 3, 4], "hello", 10],
-):
-    if metadata.get_parameter(key) != value:
-        raise RuntimeError(
-            f"Metadata parameter {key} does not match the expected value, got {metadata.get_parameter(key)} but expected {value}"
-        )
+
 for rntuple in [
     "functional_producer_rntuple.root",
     "functional_producer_rntuple_file.root",

--- a/test/k4FWCoreTest/scripts/CheckOutputFiles.py
+++ b/test/k4FWCoreTest/scripts/CheckOutputFiles.py
@@ -229,25 +229,15 @@ check_metadata(
         "PDGValues": [1, 2, 3, 4],
         "MetadataString": "hello",
         "FinalizeMetadataInt": 10,
+        "PythonIntParam": 42,
+        "PythonFloatParam": 4.0,
+        "PythonDoubleParam": 3.14,
+        "PythonStringParam": "hello from python",
+        "PythonFinalizeParam": 99,
     },
 )
 
-reader = podio.reading.get_reader("functional_metadata.root")
-metadata = reader.get("metadata")[0]
-for key, value in zip(
-    [
-        "NumberOfParticles",
-        "ParticleTime",
-        "PDGValues",
-        "MetadataString",
-        "FinalizeMetadataInt",
-    ],
-    [3, 1.5, [1, 2, 3, 4], "hello", 10],
-):
-    if metadata.get_parameter(key) != value:
-        raise RuntimeError(
-            f"Metadata parameter {key} does not match the expected value, got {metadata.get_parameter(key)} but expected {value}"
-        )
+
 for rntuple in [
     "functional_producer_rntuple.root",
     "functional_producer_rntuple_file.root",


### PR DESCRIPTION
BEGINRELEASENOTES
- Allow pre-filling parameters for the MetadataSvc, through int, float, double of str parameters
- Add a python function to allow passing a dictionary and letting Python infer which type is passed
- Modify a test checking that it is possible to pass parameters by hand or use the function to put them and also that overwriting happens and they are present in the resulting file


ENDRELEASENOTES

- Double or float by default?
- Global setting for setting all the parameters at `finalize()`? Otherwise it has to be a setting per-parameter
- Does this solve what we need for k4MarlinWrapper?