### PR TITLE
Make OutputCollection of CollectionMerger and input and output collections of EfficiencyFilter take a single argument

### DIFF
--- a/k4FWCore/components/CollectionMerger.cpp
+++ b/k4FWCore/components/CollectionMerger.cpp
@@ -48,7 +48,7 @@ struct CollectionMerger final
     : k4FWCore::Transformer<podio::CollectionBase*(const std::vector<const podio::CollectionBase*>&)> {
   CollectionMerger(const std::string& name, ISvcLocator* svcLoc)
       : Transformer(name, svcLoc, {KeyValues("InputCollections", {"MCParticles"})},
-                    {KeyValues("OutputCollection", {"NewMCParticles"})}) {
+                    {KeyValue("OutputCollection", "NewMCParticles")}) {
     if (System::cmdLineArgs()[0].find("genconf") != std::string::npos) {
       return;
     }

--- a/k4FWCore/components/EfficiencyFilter.cpp
+++ b/k4FWCore/components/EfficiencyFilter.cpp
@@ -37,8 +37,8 @@ struct ConcatTypeLists<List<Ts...>, List<Us...>> {
 struct EfficiencyFilter final : k4FWCore::Transformer<podio::CollectionBase*(const podio::CollectionBase&,
                                                                              const edm4hep::EventHeaderCollection&)> {
   EfficiencyFilter(const std::string& name, ISvcLocator* svcLoc)
-      : Transformer(name, svcLoc, {KeyValues("InputCollection", {""}), KeyValues("EventHeader", {"EventHeader"})},
-                    {KeyValues("OutputCollection", {""})}) {}
+      : Transformer(name, svcLoc, {KeyValue("InputCollection", ""), KeyValue("EventHeader", "EventHeader")},
+                    {KeyValue("OutputCollection", "")}) {}
 
   StatusCode initialize() final {
     StatusCode sc = Transformer::initialize();

--- a/test/k4FWCoreTest/options/ExampleEfficiencyFilter.py
+++ b/test/k4FWCoreTest/options/ExampleEfficiencyFilter.py
@@ -57,24 +57,24 @@ merger_links = CollectionMerger(
 
 filter_exact = EfficiencyFilter(
     "Filter",
-    InputCollection=["MergedMCParticles"],
-    OutputCollection=["FilteredMCParticles"],
+    InputCollection="MergedMCParticles",
+    OutputCollection="FilteredMCParticles",
     Efficiency=0.8,
     Exact=True,  # If True, then 80% of the MCP, for each event, will be kept (for an event with 10 MCP, 8 will be kept always)
 )
 
 filter = EfficiencyFilter(
     "FilterNotExact",
-    InputCollection=["MergedMCParticles"],
-    OutputCollection=["FilteredNotExactMCParticles"],
+    InputCollection="MergedMCParticles",
+    OutputCollection="FilteredNotExactMCParticles",
     Efficiency=0.8,
     Exact=False,  # If False (default), every MCP will be kept with a probability of 0.8 (roll the dice for each MCP)
 )
 
 filter_links = EfficiencyFilter(
     "FilterLinks",
-    InputCollection=["MergedLinks"],
-    OutputCollection=["FilteredLinks"],
+    InputCollection="MergedLinks",
+    OutputCollection="FilteredLinks",
     Efficiency=0.8,
     Exact=True,
 )

--- a/test/k4FWCoreTest/options/ExampleEfficiencyFilter.py
+++ b/test/k4FWCoreTest/options/ExampleEfficiencyFilter.py
@@ -46,13 +46,13 @@ header_producer = EventHeaderCreator("EventHeaderCreator")
 merger = CollectionMerger(
     "CollectionMerger",
     InputCollections=["MCParticles1"] * 10,
-    OutputCollection=["MergedMCParticles"],
+    OutputCollection="MergedMCParticles",
 )
 
 merger_links = CollectionMerger(
     "LinksMerger",
     InputCollections=["Links"] * 10,
-    OutputCollection=["MergedLinks"],
+    OutputCollection="MergedLinks",
 )
 
 filter_exact = EfficiencyFilter(

--- a/test/k4FWCoreTest/options/ExampleFunctionalCollectionMerger.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalCollectionMerger.py
@@ -52,7 +52,7 @@ merger = CollectionMerger(
     # List of collections to concatenate
     InputCollections=["MCParticles2", "MCParticles1", "MCParticles3"],
     # Name of the single output collection
-    OutputCollection=["NewMCParticles"],
+    OutputCollection="NewMCParticles",
     OutputLevel=DEBUG,
 )
 
@@ -61,7 +61,7 @@ link_merger = CollectionMerger(
     # List of collections to concatenate
     InputCollections=["Links", "Links"],
     # Name of the single output collection
-    OutputCollection=["NewLinks"],
+    OutputCollection="NewLinks",
 )
 
 # If we want to copy instead of creating a subset collection


### PR DESCRIPTION
It doesn't need to take multiple collections


BEGINRELEASENOTES
- Make the `CollectionMerger.OutputCollection` accept a single collection (and disallow passing a list).
- Same for the `EfficiencyFilter`, for both its input and output collections.

ENDRELEASENOTES


Just stumbled over this. I suppose we never changed this after #345. Maybe because it would break in many places and we don't have an easy transparent migration for this?