### PR TITLE
Update k4FWCore after DataHandleMixin has been deprecated

### DIFF
--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -22,6 +22,7 @@
 #include "Gaudi/Functional/details.h"
 #include "Gaudi/Functional/utilities.h"
 #include "GaudiKernel/FunctionalFilterDecision.h"
+#include "GAUDI_VERSION.h"
 
 // #include "GaudiKernel/CommonMessaging.h"
 
@@ -37,15 +38,19 @@ namespace k4FWCore {
 
 namespace details {
 
+#if GAUDI_MAJOR_VERSION >= 41
+  using EmptyTypeList = Gaudi::Functional::details::type_list<>;
+#else
+  using EmptyTypeList = std::tuple<>;
+#endif
+
   template <typename Signature, typename Traits_>
   struct Consumer;
 
   template <typename... In, typename Traits_>
   struct Consumer<void(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                    Gaudi::Functional::details::type_list<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<
-        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In> ||
                     std::is_same_v<In, EventContext>) &&
@@ -54,8 +59,7 @@ namespace details {
 
     static constexpr size_t N_in = filter_evtcontext<In...>::size;
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -19,10 +19,10 @@
 #ifndef FWCORE_CONSUMER_H
 #define FWCORE_CONSUMER_H
 
+#include "GAUDI_VERSION.h"
 #include "Gaudi/Functional/details.h"
 #include "Gaudi/Functional/utilities.h"
 #include "GaudiKernel/FunctionalFilterDecision.h"
-#include "GAUDI_VERSION.h"
 
 // #include "GaudiKernel/CommonMessaging.h"
 

--- a/k4FWCore/include/k4FWCore/Consumer.h
+++ b/k4FWCore/include/k4FWCore/Consumer.h
@@ -42,8 +42,10 @@ namespace details {
 
   template <typename... In, typename Traits_>
   struct Consumer<void(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                    Gaudi::Functional::details::type_list<>, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<
+        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In> ||
                     std::is_same_v<In, EventContext>) &&
@@ -52,7 +54,8 @@ namespace details {
 
     static constexpr size_t N_in = filter_evtcontext<In...>::size;
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -19,9 +19,9 @@
 #ifndef FWCORE_TRANSFORMER_H
 #define FWCORE_TRANSFORMER_H
 
+#include "GAUDI_VERSION.h"
 #include "Gaudi/Functional/details.h"
 #include "Gaudi/Functional/utilities.h"
-#include "GAUDI_VERSION.h"
 
 #include "k4FWCore/FunctionalUtils.h"
 

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -41,8 +41,10 @@ namespace details {
 
   template <typename Out, typename... In, typename Traits_>
   struct Transformer<Out(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                    Gaudi::Functional::details::type_list<>, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<
+        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In> ||
                     std::is_same_v<In, EventContext>) &&
@@ -55,7 +57,8 @@ namespace details {
     static constexpr std::size_t N_in = filter_evtcontext<In...>::size;
     static constexpr std::size_t N_out = 1;
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;
@@ -201,8 +204,10 @@ namespace details {
 
   template <typename... Out, typename... In, typename Traits_>
   struct MultiTransformer<std::tuple<Out...>(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                    Gaudi::Functional::details::type_list<>, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<
+        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value ||
                     std::is_same_v<In, EventContext>) &&
@@ -214,7 +219,8 @@ namespace details {
     static constexpr std::size_t N_in = filter_evtcontext<In...>::size;
     static constexpr std::size_t N_out = sizeof...(Out);
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<std::tuple<>, std::tuple<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
+                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;

--- a/k4FWCore/include/k4FWCore/Transformer.h
+++ b/k4FWCore/include/k4FWCore/Transformer.h
@@ -21,6 +21,7 @@
 
 #include "Gaudi/Functional/details.h"
 #include "Gaudi/Functional/utilities.h"
+#include "GAUDI_VERSION.h"
 
 #include "k4FWCore/FunctionalUtils.h"
 
@@ -36,15 +37,19 @@ namespace k4FWCore {
 
 namespace details {
 
+#if GAUDI_MAJOR_VERSION >= 41
+  using EmptyTypeList = Gaudi::Functional::details::type_list<>;
+#else
+  using EmptyTypeList = std::tuple<>;
+#endif
+
   template <typename Signature, typename Traits_>
   struct Transformer;
 
   template <typename Out, typename... In, typename Traits_>
   struct Transformer<Out(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                    Gaudi::Functional::details::type_list<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<
-        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike_v<In> ||
                     std::is_same_v<In, EventContext>) &&
@@ -57,8 +62,7 @@ namespace details {
     static constexpr std::size_t N_in = filter_evtcontext<In...>::size;
     static constexpr std::size_t N_out = 1;
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;
@@ -204,10 +208,8 @@ namespace details {
 
   template <typename... Out, typename... In, typename Traits_>
   struct MultiTransformer<std::tuple<Out...>(const In&...), Traits_>
-      : Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                    Gaudi::Functional::details::type_list<>, Traits_> {
-    using Gaudi::Functional::details::DataHandleMixin<
-        Gaudi::Functional::details::type_list<>, Gaudi::Functional::details::type_list<>, Traits_>::DataHandleMixin;
+      : Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_> {
+    using Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>::DataHandleMixin;
 
     static_assert(((std::is_base_of_v<podio::CollectionBase, In> || isVectorLike<In>::value ||
                     std::is_same_v<In, EventContext>) &&
@@ -219,8 +221,7 @@ namespace details {
     static constexpr std::size_t N_in = filter_evtcontext<In...>::size;
     static constexpr std::size_t N_out = sizeof...(Out);
 
-    using base_class = Gaudi::Functional::details::DataHandleMixin<Gaudi::Functional::details::type_list<>,
-                                                                   Gaudi::Functional::details::type_list<>, Traits_>;
+    using base_class = Gaudi::Functional::details::DataHandleMixin<EmptyTypeList, EmptyTypeList, Traits_>;
 
     using KeyValue = base_class::KeyValue;
     using KeyValues = base_class::KeyValues;


### PR DESCRIPTION
BEGINRELEASENOTES
- Update k4FWCore after DataHandleMixin has been deprecated. Use `Gaudi::Functional::details::type_list` instead. See https://gitlab.cern.ch/gaudi/Gaudi/-/merge_requests/1920

ENDRELEASENOTES