### PR TITLE
Check for files that don't exist to exit early if any file doesn't exist

### DIFF
--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -78,7 +78,9 @@ class ApplicationMgr:
         # ROOT can read remote files that os.path.isfile cannot check.
         for f in iosvc_props[inp][0]:
             if "://" not in f and not os.path.isfile(f):
-                raise FileNotFoundError(f"Input file '{f}' does not exist or is not a regular file")
+                raise FileNotFoundError(
+                    f"Input file '{f}' does not exist or is not a regular file"
+                )
 
         collections = iosvc_props["CollectionNames"][0] or None
         n_events = self._mgr.EvtMax

--- a/python/k4FWCore/ApplicationMgr.py
+++ b/python/k4FWCore/ApplicationMgr.py
@@ -23,6 +23,8 @@ from Configurables import Reader, Writer, IOSvc, Gaudi__Sequencer, EventLoopMgr
 from Gaudi.Configuration import WARNING, VERBOSE
 from k4FWCore.utils import get_logger
 
+import os
+
 logger = get_logger()
 
 
@@ -70,6 +72,13 @@ class ApplicationMgr:
         if not inp:
             # We have got nothing to do here, since there is no input
             return
+
+        # Verify all input files exist to fail early.
+        # Skip paths with a protocol scheme (e.g. root://, https://) since
+        # ROOT can read remote files that os.path.isfile cannot check.
+        for f in iosvc_props[inp][0]:
+            if "://" not in f and not os.path.isfile(f):
+                raise FileNotFoundError(f"Input file '{f}' does not exist or is not a regular file")
 
         collections = iosvc_props["CollectionNames"][0] or None
         n_events = self._mgr.EvtMax

--- a/test/k4FWCoreTest/CMakeLists.txt
+++ b/test/k4FWCoreTest/CMakeLists.txt
@@ -56,6 +56,7 @@ set(k4fwcoretest_plugin_sources
   src/components/k4FWCoreTest_CreateExampleEventData.cpp
   src/components/k4FWCoreTest_CreateMarlinWrapperCollection.cpp
   src/components/k4FWCoreTest_HelloWorldAlg.cpp
+  src/components/TestService.cpp
   src/components/TestUniqueIDGenSvc.cpp
   src/components/TypeMisMatchDemo.cpp
 )
@@ -218,7 +219,8 @@ add_test_fwcore(createEventHeaderConcurrent options/createEventHeaderConcurrent.
 add_test_fwcore(FunctionalMetadataReadOldAlgorithm options/ExampleFunctionalMetadataReadOldAlgorithm.py PROPERTIES FIXTURES_REQUIRED OldAlgorithmFile ADD_TO_CHECK_FILES)
 
 add_test_fwcore(FunctionalNonExistingFile options/ExampleFunctionalNonExistingFile.py)
-set_tests_properties(FunctionalNonExistingFile PROPERTIES PASS_REGULAR_EXPRESSION "does not exist")
+set_tests_properties(FunctionalNonExistingFile PROPERTIES PASS_REGULAR_EXPRESSION "does not exist"
+  FAIL_REGULAR_EXPRESSION "TestService initialized")
 add_test_fwcore(FunctionalNonExistingFileOverwritten options/ExampleFunctionalNonExistingFile.py --IOSvc.Input functional_producer.root PROPERTIES FIXTURES_REQUIRED ProducerFile)
 add_test_fwcore(FunctionalFileTooLong options/ExampleFunctionalFile.py -n 999 --IOSvc.Output toolong.root PROPERTIES FIXTURES_REQUIRED ProducerFile PASS_REGULAR_EXPRESSION
                   "Application Manager Terminated successfully with a user requested ScheduledStop")

--- a/test/k4FWCoreTest/options/ExampleFunctionalNonExistingFile.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalNonExistingFile.py
@@ -22,10 +22,14 @@
 from Gaudi.Configuration import INFO
 from Configurables import ExampleFunctionalTransformer
 from Configurables import EventDataSvc
+from Configurables import TestService
 from k4FWCore import ApplicationMgr, IOSvc
 
 svc = IOSvc()
 svc.Input = "non_existing_file.root"
+
+earlyExit = TestService("TestService")
+testsvc = TestService("TestService")
 
 transformer = ExampleFunctionalTransformer(
     "Transformer", InputCollection="MCParticles", OutputCollection="NewMCParticles"
@@ -35,6 +39,6 @@ mgr = ApplicationMgr(
     TopAlg=[transformer],
     EvtSel="NONE",
     EvtMax=-1,
-    ExtSvc=[EventDataSvc("EventDataSvc")],
+    ExtSvc=[EventDataSvc("EventDataSvc"), testsvc],
     OutputLevel=INFO,
 )

--- a/test/k4FWCoreTest/options/ExampleFunctionalNonExistingFile.py
+++ b/test/k4FWCoreTest/options/ExampleFunctionalNonExistingFile.py
@@ -28,7 +28,6 @@ from k4FWCore import ApplicationMgr, IOSvc
 svc = IOSvc()
 svc.Input = "non_existing_file.root"
 
-earlyExit = TestService("TestService")
 testsvc = TestService("TestService")
 
 transformer = ExampleFunctionalTransformer(

--- a/test/k4FWCoreTest/src/components/TestService.cpp
+++ b/test/k4FWCoreTest/src/components/TestService.cpp
@@ -21,10 +21,8 @@
 DECLARE_COMPONENT(TestService)
 
 StatusCode TestService::initialize() {
-  info() << "TestService initialized -- if you see this the early exit did NOT work" << endmsg;
+  info() << "TestService initialized" << endmsg;
   return Service::initialize();
 }
 
-StatusCode TestService::finalize() {
-  return Service::finalize();
-}
+StatusCode TestService::finalize() { return Service::finalize(); }

--- a/test/k4FWCoreTest/src/components/TestService.cpp
+++ b/test/k4FWCoreTest/src/components/TestService.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "TestService.h"
+
+DECLARE_COMPONENT(TestService)
+
+StatusCode TestService::initialize() {
+  info() << "TestService initialized -- if you see this the early exit did NOT work" << endmsg;
+  return Service::initialize();
+}
+
+StatusCode TestService::finalize() {
+  return Service::finalize();
+}

--- a/test/k4FWCoreTest/src/components/TestService.h
+++ b/test/k4FWCoreTest/src/components/TestService.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014-2024 Key4hep-Project.
+ *
+ * This file is part of Key4hep.
+ * See https://key4hep.github.io/key4hep-doc/ for further info.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef K4FWCORETEST_TESTEARLYEXITSVC_H
+#define K4FWCORETEST_TESTEARLYEXITSVC_H
+
+#include "GaudiKernel/Service.h"
+
+class TestService : public Service {
+public:
+  using Service::Service;
+  StatusCode initialize() override;
+  StatusCode finalize() override;
+};
+
+#endif

--- a/test/k4FWCoreTest/src/components/TestService.h
+++ b/test/k4FWCoreTest/src/components/TestService.h
@@ -16,8 +16,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef K4FWCORETEST_TESTEARLYEXITSVC_H
-#define K4FWCORETEST_TESTEARLYEXITSVC_H
+#ifndef K4FWCORETEST_TESTSERVICE_H
+#define K4FWCORETEST_TESTSERVICE_H
 
 #include "GaudiKernel/Service.h"
 


### PR DESCRIPTION
BEGINRELEASENOTES
- Check for files that don't exist to exit early if any file doesn't exist
- Add a test service and make the test that checks for non existing files check that the test service was not initialized

ENDRELEASENOTES

A typical example is when the input file is not found but `GeoSvc` is still initialized, which means that the geometry is built anyway only to fail after that.