### PR TITLE
Don't require `equality_comparable` in `putParameter`

### DIFF
--- a/k4FWCore/include/k4FWCore/MetadataUtils.h
+++ b/k4FWCore/include/k4FWCore/MetadataUtils.h
@@ -48,7 +48,7 @@ concept Streamable = requires(std::ostream& os, const T& v) {
 ///             parameter, typically "this"
 /// @tparam GaudiComp The type of the component. This will be deduced in
 ///                   pretty much all of the use cases
-template <std::equality_comparable T, typename GaudiComp>
+template <typename T, typename GaudiComp>
 void putParameter(const std::string& name, const T& value, const GaudiComp* comp) {
   comp->debug() << "Trying to put parameter '" << name << "'";
   if constexpr (Streamable<T>) {
@@ -62,8 +62,10 @@ void putParameter(const std::string& name, const T& value, const GaudiComp* comp
   }
   const auto existing = metadataSvc->template get<T>(name);
   if (existing.has_value()) {
-    if (metadataSvc->skipIfSameValue() && *existing == value) {
-      return;
+    if constexpr (std::equality_comparable<T>) {
+      if (metadataSvc->skipIfSameValue() && *existing == value) {
+        return;
+      }
     }
     if (metadataSvc->throwIfDuplicate()) {
       throw GaudiException("Metadata parameter '" + name + "' is already set", comp->name(), StatusCode::FAILURE);


### PR DESCRIPTION
Fixes the build against recent EDM4hep, where `edm4hep::utils::ParticleIDMeta` is no longer `std::equality_comparable` (its `algoType` member became private, removing the defaulted `operator==`). `putParameter` required that concept only for the `*existing == value` comparison behind `skipIfSameValue()`.

This relaxes the template constraint and guards the comparison with `if constexpr (std::equality_comparable<T>)`. For non-comparable metadata types the "skip if identical value" shortcut is bypassed; all other behaviour is unchanged.

BEGINRELEASENOTES
- Fix compilation of `putParameter` with metadata types that are not `std::equality_comparable` (e.g. `edm4hep::utils::ParticleIDMeta` in recent EDM4hep). The `skipIfSameValue()` optimization is now only applied when the type supports `==`.

ENDRELEASENOTES