### PR TITLE
Use GCC 16 for the dev3 stack

### DIFF
--- a/.github/workflows/dev3-build.yaml
+++ b/.github/workflows/dev3-build.yaml
@@ -40,4 +40,4 @@ jobs:
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
-        stack: /cvmfs/sft-nightlies.cern.ch/lcg/views/dev3/latest/x86_64-el9-gcc14-opt/setup.sh
+        stack: /cvmfs/sft-nightlies.cern.ch/lcg/views/dev3/latest/x86_64-el9-gcc16-opt/setup.sh


### PR DESCRIPTION
- Follow up on #421

BEGINRELEASENOTES
 - Switch the dev3 CI stack to GCC 16.

ENDRELEASENOTES